### PR TITLE
Pin Faker dependency. Specify decimals in test

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ black==21.9b0
 coverage==5.5
 coveralls==3.2.0
 factory-boy==3.2.0
+Faker==9.2.0
 flake8==3.9.2
 isort==5.9.3
 pre-commit==2.15.0

--- a/src/chains/tests/test_views.py
+++ b/src/chains/tests/test_views.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from django.urls import reverse
 from faker import Faker
 from rest_framework.test import APITestCase
@@ -304,7 +306,9 @@ class ChainGasPriceTests(APITestCase):
                 "type": "oracle",
                 "uri": gas_price_50.oracle_uri,
                 "gas_parameter": gas_price_50.oracle_parameter,
-                "gwei_factor": str(gas_price_50.gwei_factor),
+                "gwei_factor": str(
+                    gas_price_50.gwei_factor.quantize(Decimal("1.000000000"))
+                ),
             },
             {
                 "type": "fixed",


### PR DESCRIPTION
- Pin `Faker` dependency to version `9.2.0` – `Faker` was being provided transitively even though it is used directly in the project.
- The transition to the new `Faker` version would generate decimals without the required 9 decimal cases (as the endpoint specifies) so the test now uses `Decimal.quantize` to specify the number of expected decimals.