### PR TITLE
Remove docker development image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,8 +149,6 @@ jobs:
         with:
           context: .
           push: true
-          # Target production image from multi-stage build (check Dockerfile)
-          target: production
           tags: gnosispm/safe-config-service:${{ env.DOCKER_TAG }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim as production
+FROM python:3.9-slim
 
 # python
 ENV PYTHONUNBUFFERED=1
@@ -22,9 +22,3 @@ RUN set ex \
     && chmod +x /usr/bin/tini
 
 ENTRYPOINT ["/usr/bin/tini", "--", "./docker-entrypoint.sh"]
-
-# ------- development image -------
-FROM production as development
-
-ENV PATH="${PATH}:${PYTHONUSERBASE}/bin"
-RUN pip3 install --no-warn-script-location --user -r requirements-dev.txt


### PR DESCRIPTION
- The development image was not really being used for local development – on the CI the only target that was built was `production`
- For local development, the recommended way is to spin up a database (with `docker compose`) and use run Django locally (with `venv`)