### PR TITLE
Add url filter for SafeApps

### DIFF
--- a/src/safe_apps/tests/test_views.py
+++ b/src/safe_apps/tests/test_views.py
@@ -574,3 +574,31 @@ class TagsTests(APITestCase):
         json_response = response.json()
         self.assertEqual(response.status_code, 200)
         self.assertEqual(json_response[0]["tags"], [tag_2.name, tag_1.name])
+
+
+class SafeAppsUrlQueryTests(APITestCase):
+    def test_query_url_match(self) -> None:
+        safe_app = SafeAppFactory.create()
+        url = reverse("v1:safe-apps:list") + f"?url={safe_app.url}"
+
+        response = self.client.get(path=url, data=None, format="json")
+
+        json_response = response.json()
+        self.assertEqual(response.status_code, 200)
+        # There should be a non-empty list
+        self.assertTrue(len(json_response) > 0)
+        # All items should have safe_app.url as the url
+        self.assertTrue(
+            all(map(lambda item: item["url"] == safe_app.url, json_response))
+        )
+
+    def test_query_url_no_match(self) -> None:
+        safe_app = SafeAppFactory.create(url="http://test.com")
+        query_url = safe_app.url + "/"
+        url = reverse("v1:safe-apps:list") + f"?url={query_url}"
+
+        response = self.client.get(path=url, data=None, format="json")
+
+        json_response = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(json_response) == 0)

--- a/src/safe_apps/views.py
+++ b/src/safe_apps/views.py
@@ -32,7 +32,7 @@ class SafeAppsListView(ListAPIView):
     _swagger_url_param = openapi.Parameter(
         "url",
         openapi.IN_QUERY,
-        description="Filter Safe Apps available from `url`",
+        description="Filter Safe Apps available from `url`. `url` needs to be an exact match",
         type=openapi.TYPE_STRING,
     )
 

--- a/src/safe_apps/views.py
+++ b/src/safe_apps/views.py
@@ -29,9 +29,21 @@ class SafeAppsListView(ListAPIView):
         description="Used to filter Safe Apps that are available on `clientUrl`",
         type=openapi.TYPE_STRING,
     )
+    _swagger_url_param = openapi.Parameter(
+        "url",
+        openapi.IN_QUERY,
+        description="Filter Safe Apps available from `url`",
+        type=openapi.TYPE_STRING,
+    )
 
     @method_decorator(cache_page(60 * 10, cache="safe-apps"))  # Cache 10 minutes
-    @swagger_auto_schema(manual_parameters=[_swagger_chain_id_param, _swagger_client_url_param])  # type: ignore[misc]
+    @swagger_auto_schema(
+        manual_parameters=[
+            _swagger_chain_id_param,
+            _swagger_client_url_param,
+            _swagger_url_param,
+        ]
+    )  # type: ignore[misc]
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         Returns a collection of Safe Apps (across different chains).
@@ -51,5 +63,9 @@ class SafeAppsListView(ListAPIView):
             queryset = queryset.filter(
                 Q(exclusive_clients__url=client_url) | Q(exclusive_clients__isnull=True)
             )
+
+        url = self.request.query_params.get("url")
+        if url:
+            queryset = queryset.filter(url=url)
 
         return queryset


### PR DESCRIPTION
See https://github.com/safe-global/safe-client-gateway/issues/855

- Add query parameter to `SafeAppsListView` which matches the `url` field of a `SafeApp`
- The url needs to be an exact match ie.: the protocol, path, any slash, query parameter, etc. need to be the same

```javascript
GET /api/v1/safe-apps/?url=https%3A%2F%2Fapp.aave.com

[
  {
    "id": 1,
    "url": "https://app.aave.com",
    "name": "Aave v2",
    ...
]
```