### PR TITLE
add meter network mainnet and testnet chain infos to safe-config

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ gunicorn==20.1.0
 Pillow==9.1.1
 psycopg2-binary==2.9.3
 requests==2.27.1
+


### PR DESCRIPTION
Meter mainnet Chain Info
chainId: 82
chainName: Meter mainnet
block explorer base: https://scan.meter.io/
tx template: https://scan.meter.io/tx/{tx}
address template: https://scan.meter.io/address/{address}
nativeCurrency: {
  name: MeterStable Token,
  symbol: MTR,
  decimals: 18,
  logoUrl: https://github.com/meterio/token-list/blob/master/data/MTR/logo.png
}


Meter Testnet ChainInfo
chainId: 83
chainName: Meter testnet
block explorer base: https://scan-warringstakes.meter.io/
tx template: https://scan-warringstakes.meter.io/tx/{tx}
address template: https://scan-warringstakes.meter.io/address/{address}
nativeCurrency: {
  name: MeterStable Token,
  symbol: MTR,
  decimals: 18,
  logoUrl: https://github.com/meterio/token-list/blob/master/data/MTR/logo.png
}