### PR TITLE
Revert "Uncomment POSTGRES_PASSWORD on environment example file (#558)"

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,7 +54,7 @@ NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx/
 # You'll always want to set the POSTGRES_USER and POSTGRES_PASSWORD since the
 # postgres Docker image uses them for its default database user and password.
 #POSTGRES_USER=postgres
-POSTGRES_PASSWORD=postgres
+#POSTGRES_PASSWORD=postgres
 POSTGRES_NAME=postgres
 POSTGRES_HOST=db
 POSTGRES_PORT=5432


### PR DESCRIPTION
This reverts commit 37442835991425874e57027e02d0a07fa2ff0211.

The `.env.sample` file contains production ready defaults. If this needs to change it'd be a bigger change than just this field. See: https://github.com/safe-global/safe-config-service/blob/eca3fa3f5474cbb7a9273592af25fcea8c54ee71/.env.example#L1-L6