### PR TITLE
Remove --no-cache-dir option from Github Action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
           python-version: '3.10'
       - name: Install dependencies
         run: |
-          pip install -U --no-cache-dir wheel setuptools
+          pip install -U wheel setuptools
           pip install -r requirements-dev.txt
       - name: Run mypy
         run: mypy --strict src/chains src/safe_apps


### PR DESCRIPTION
- We delegate caching to `actions/cache@v3` as long dependencies are installed in `~/.cache/pip`