### PR TITLE
Set localhost as trusted origin in sample .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,6 +108,7 @@ DEFAULT_FILE_STORAGE=storages.backends.s3boto3.S3Boto3Storage
 #AWS_S3_CUSTOM_DOMAIN=
 
 # CSRF protection 
-# See https://docs.djangoproject.com/en/4.0/ref/settings/#std:setting-CSRF_TRUSTED_ORIGINS
+# See https://docs.djangoproject.com/en/dev/ref/settings/#csrf-trusted-origins
+CSRF_TRUSTED_ORIGINS="http://localhost:${NGINX_HOST_PORT}"
 #CSRF_TRUSTED_ORIGINS="https://safe-config.staging.gnosisdev.com,http://safe-config.staging.gnosisdev.com"
 #CSRF_TRUSTED_ORIGINS="https://safe-config.gnosis.io,http://safe-config.gnosis.io"


### PR DESCRIPTION
Closes #560

- Fix CSRF validation when running with `nginx` container locally
- With the default settings provided in `.env.sample` and using Docker with the `nginx` container, `POST` requests fail (this can be verified by trying to login in the admin interface)
- This is part of the effort to provide development-ready defaults