### PR TITLE
Set `latest` docker tag on releases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,10 +114,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: coveralls --service=github
 
-  docker-publish:
-    if: |
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      (github.event_name == 'release' && github.event.action == 'released')
+  docker-publish-staging:
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main')
     needs: [ flake8, isort, black, django-check ]
     runs-on: ubuntu-latest
     steps:
@@ -137,21 +135,55 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Set tag (staging)
-        # Set "staging" as Docker tag if the event is a push to main branch
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: echo "DOCKER_TAG=staging" >> $GITHUB_ENV
-      - name: Set tag (release)
-        # Set the tag versions as Docker tag if it is a release event
-        if: github.event_name == 'release' && github.event.action == 'released'
-        run: echo "DOCKER_TAG=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v3.2.0
         with:
           context: .
           push: true
-          tags: gnosispm/safe-config-service:${{ env.DOCKER_TAG }}
+          tags: gnosispm/safe-config-service:staging
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+      - # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}
+
+  docker-publish-release:
+    if: (github.event_name == 'release' && github.event.action == 'released')
+    needs: [ flake8, isort, black, django-check ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2.2.1
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Login to DockerHub
+        uses: docker/login-action@v2.1.0
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v3.2.0
+        with:
+          context: .
+          push: true
+          tags: |
+            gnosispm/safe-config-service:${{ github.event.release.tag_name }}
+            gnosispm/safe-config-service:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
       - # Temp fix
@@ -166,7 +198,7 @@ jobs:
 
   autodeploy:
     runs-on: ubuntu-latest
-    needs: [docker-publish]
+    needs: [docker-publish-staging]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
- We took a look on the different official dockerhub images (https://hub.docker.com/search?q=&type=image&image_filter=official) and they all follow the same "de facto" standard of setting `latest` to the last release of the application.
- They use `stable` for older versions or LTS, and in our case we don't have that and we want users running the last versions of our services.
- With this `latest` tag it will be easy for users to be updated and not having to manually update versions (like in https://github.com/safe-global/safe-infrastructure)
- Also make docker staging/release pushes different jobs
