### PR TITLE
Reject null input for safe apps filters

### DIFF
--- a/src/safe_apps/tests/test_views.py
+++ b/src/safe_apps/tests/test_views.py
@@ -267,6 +267,16 @@ class FilterSafeAppListViewTests(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertCountEqual(response.json(), json_response)
 
+    def test_apps_returned_on_null_client_url(self) -> None:
+        url = reverse("v1:safe-apps:list") + "?clientUrl=\0"
+        response = self.client.get(path=url, data=None, format="json")
+        self.assertEqual(response.status_code, 200)
+
+    def test_apps_returned_on_null_url(self) -> None:
+        url = reverse("v1:safe-apps:list") + "?url=\0"
+        response = self.client.get(path=url, data=None, format="json")
+        self.assertEqual(response.status_code, 200)
+
     def test_apps_returned_on_empty_client_url(self) -> None:
         client_1 = ClientFactory.create(url="safe.com")
         safe_app_1 = SafeAppFactory.create()

--- a/src/safe_apps/views.py
+++ b/src/safe_apps/views.py
@@ -59,13 +59,13 @@ class SafeAppsListView(ListAPIView):
             queryset = queryset.filter(chain_ids__contains=[chain_id])
 
         client_url = self.request.query_params.get("clientUrl")
-        if client_url:
+        if client_url and "\0" not in client_url:
             queryset = queryset.filter(
                 Q(exclusive_clients__url=client_url) | Q(exclusive_clients__isnull=True)
             )
 
         url = self.request.query_params.get("url")
-        if url:
+        if url and "\0" not in url:
             queryset = queryset.filter(url=url)
 
         return queryset


### PR DESCRIPTION
- Closes #697

I provided a quick PR for this, but the right solution would be using Django filtering (I don't know if it's worth it to migrate now): https://www.django-rest-framework.org/api-guide/filtering/

As you can see this protection is provided by default: https://github.com/encode/django-rest-framework/blob/c10f2266222c434485889b08cc1463acdb8fa169/rest_framework/fields.py#L739