### PR TITLE
Add default environment variables to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,10 +9,10 @@ services:
     env_file:
       - .dev.env
     ports:
-      - "${NGINX_HOST_PORT}:80"
+      - "${NGINX_HOST_PORT:-8080}:80"
     volumes:
       - ./nginx/templates:/etc/nginx/templates
-      - nginx-shared:${DOCKER_NGINX_VOLUME_ROOT}
+      - nginx-shared:${DOCKER_NGINX_VOLUME_ROOT-/nginx}
     depends_on:
       - web
   db:
@@ -22,12 +22,12 @@ services:
     volumes:
       - ./data/db:/var/lib/postgresql/data
     ports:
-      - "${POSTGRES_PORT}:5432"
+      - "${POSTGRES_PORT:-5432}:5432"
   web:
     build: .
     tty: true
     volumes:
-      - nginx-shared:${DOCKER_NGINX_VOLUME_ROOT}
+      - nginx-shared:${DOCKER_NGINX_VOLUME_ROOT:-/nginx}
     env_file:
       - .dev.env
     environment:


### PR DESCRIPTION
Closes https://github.com/safe-global/safe-config-service/issues/728

- If no environment variables are not set (more specifically `NGINX_HOST_PORT`, `POSTGRES_PORT` and `DOCKER_NGINX_VOLUME_ROOT`) then docker-compose fails to start the containers
- Even though the variables are set as an example in `.dev.env` which is read by `env_file`, those variables will only be available to the container and not to the docker-compose.yml file