### PR TITLE
docs: fix docker permission denied error

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ pip install -r requirements-dev.txt
 #### 2. Launch the Postgres database image
 
 ```shell
-docker compose up -d db
+sudo docker compose up -d db
 ```
 
 #### 3. Execute pending database migrations
@@ -66,7 +66,7 @@ Pytest is used to run the available tests in the project. **Some of these tests 
 so having one running is required**. From the project root:
 
 ```shell
-docker compose up -d db
+sudo docker compose up -d db
 pytest src
 ```
 


### PR DESCRIPTION
The below error would occur when run `docker compose up -d db` as a nonprivileged user:
```
permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Get "http://%2Fvar%2Frun%2Fdocker.sock/v1.24/containers/json?all=1&filters=%7B%22label%22%3A%7B%22com.docker.compose.project%3Dsafe-config-service%22%3Atrue%7D%7D": dial unix /var/run/docker.sock: connect: permission denied
```

We should use sudo to run this command.