### PR TITLE
Build and upload arm64 images

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -151,7 +151,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2.1.0
         with:
-          platforms: amd64,arm64
+          platforms: arm64
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2.4.1
       - name: Cache Docker layers
@@ -196,7 +196,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2.1.0
         with:
-          platforms: amd64,arm64
+          platforms: arm64
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2.4.1
       - name: Cache Docker layers

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,6 +148,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2.1.0
+        with:
+          platforms: amd64,arm64
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2.4.1
       - name: Cache Docker layers
@@ -167,6 +171,7 @@ jobs:
         uses: docker/build-push-action@v4.0.0
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: safeglobal/safe-config-service:staging
           cache-from: type=local,src=/tmp/.buildx-cache
@@ -188,6 +193,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2.1.0
+        with:
+          platforms: amd64,arm64
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2.4.1
       - name: Cache Docker layers
@@ -207,6 +216,7 @@ jobs:
         uses: docker/build-push-action@v4.0.0
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             safeglobal/safe-config-service:${{ github.event.release.tag_name }}


### PR DESCRIPTION
- In addition to `linux/amd64` images, build and upload `linux/arm64` images to DockerHub
- Add QEMU step to support targeting multiple platforms in the build process