### PR TITLE
Add force_segment on urljoin

### DIFF
--- a/src/clients/safe_client_gateway.py
+++ b/src/clients/safe_client_gateway.py
@@ -27,7 +27,7 @@ def flush(
         logger.error("CGW_FLUSH_TOKEN is not set. Skipping hook call")
         return
 
-    url = urljoin(cgw_url, "/v2/flush")
+    url = urljoin(cgw_url, "/v2/flush", force_segment=True)
     try:
         post = setup_session().post(
             url,


### PR DESCRIPTION
Add `force_segment` on urljoin to allow url with prefix path

example

```Python
old

cgw_url: "http://nginx:8000/cgw"

url = urljoin(cgw_url, "/v2/flush")
# HTTP://nginx:8000/v2/flush (404 ERROR)


new

cgw_url: "http://nginx:8000/cgw"

url = urljoin(cgw_url, "/v2/flush", force_segment=True)
# HTTP://nginx:8000/cgw/v2/flush (200 OK)
```