### PR TITLE
Support base url with prefix

### DIFF
--- a/src/clients/safe_client_gateway.py
+++ b/src/clients/safe_client_gateway.py
@@ -16,6 +16,12 @@ def setup_session() -> requests.Session:
     session.mount("https://", adapter)
     return session
 
+def valid_url(url) -> bool:
+    try:
+        result = urlparse(url)
+        return all([result.scheme, result.netloc])
+    except ValueError:
+        return False
 
 def flush(
     cgw_url: Optional[str], cgw_flush_token: Optional[str], json: Dict[str, Any]
@@ -23,11 +29,14 @@ def flush(
     if cgw_url is None:
         logger.error("CGW_URL is not set. Skipping hook call")
         return
+    if not valid_url(cgw_url):
+        logger.error("CGW_URL is not valid. Skipping hook call")
+        return
     if cgw_flush_token is None:
         logger.error("CGW_FLUSH_TOKEN is not set. Skipping hook call")
         return
 
-    url = urljoin(cgw_url, "/v2/flush")
+    url = cgw_url + "/v2/flush"
     try:
         post = setup_session().post(
             url,

--- a/src/clients/safe_client_gateway.py
+++ b/src/clients/safe_client_gateway.py
@@ -1,7 +1,7 @@
 import logging
 from functools import cache
 from typing import Any, Dict, Optional
-from urllib.parse import urljoin
+from urllib.parse import urlparse
 
 import requests
 


### PR DESCRIPTION
If I set `CGW_URL=http://localhost:8000/cgw`, `/cgw` will be removed and cause a 404 error.

http://localhost:8000/v2/flush (404 NOT FOUND)