### PR TITLE
Update CLA resource link

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -19,7 +19,7 @@ jobs:
           PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
           path-to-signatures: 'signatures/version1/cla.json'
-          path-to-document: 'https://safe.global/cla/'
+          path-to-document: 'https://safe.global/cla'
           # branch should not be protected
           branch: 'cla-signatures'
           allowlist: hectorgomezv,moisses89,luarx,fmrsabino,rmeissner,Uxio0,*bot # may need to update this expression if we add new bots


### PR DESCRIPTION
`https://safe.global/cla/` leads to a 404 page. Removing the end slash leads to the correct resource.