### PR TITLE
Revert "Bump drf-yasg[validation] from 1.21.5 to 1.21.6"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ djangorestframework==3.14.0
 djangorestframework-camel-case==1.4.2
 django-storages==1.13.2
 django-stubs-ext==4.2.1
-drf-yasg[validation]==1.21.6
+drf-yasg[validation]==1.21.5
 safe-eth-py[django]==5.1.0
 gunicorn==20.1.0
 Pillow==9.5.0


### PR DESCRIPTION
This revert is needed because some incompatibilities are breaking Swagger UI view.

- Reverts https://github.com/safe-global/safe-config-service/pull/880
- Wait for https://github.com/axnsan12/drf-yasg/issues/856 to be released

FYI: (Same scenario in https://github.com/safe-global/safe-transaction-service/pull/1531)