### PR TITLE
Remove coveralls dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,11 +135,8 @@ jobs:
         run: python src/manage.py check
       - name: Run tests with coverage
         run: coverage run -m pytest src
-      - name: Upload coverage
-        continue-on-error: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: coveralls --service=github
+      - name: Coveralls
+        uses: coverallsapp/github-action@v2
 
   docker-publish-staging:
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main')

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 -r requirements.txt
 black==23.3.0
 coverage==6.5.0
-coveralls==3.3.1
 factory-boy==3.2.1
 Faker==18.11.2
 flake8==6.0.0


### PR DESCRIPTION
- Removes `coveralls` from the project.
- Uses the official GitHub action from Coveralls – https://github.com/coverallsapp/github-action