### PR TITLE
Support a second Client Gateway URL

### DIFF
--- a/.dev.env
+++ b/.dev.env
@@ -69,9 +69,11 @@ GUNICORN_WEB_RELOAD=false
 
 # The Client Gateway URL. This is for triggering webhooks to invalidate its cache for example
 #CGW_URL=http://127.0.0.1
+#ALTERNATIVE_CGW_URL=
 
 # The Client Gateway /flush token.
 #CGW_FLUSH_TOKEN=example-flush-token
+#ALTERNATIVE_CGW_FLUSH_TOKEN=example-flush-token
 
 # What CPU and memory constraints will be added to your services? When left at
 # 0, they will happily use as much as needed.

--- a/src/chains/signals.py
+++ b/src/chains/signals.py
@@ -16,6 +16,8 @@ def _flush_cgw_chains() -> None:
     clients.safe_client_gateway.flush(
         cgw_url=settings.CGW_URL,
         cgw_flush_token=settings.CGW_FLUSH_TOKEN,
+        alternative_cgw_url=settings.ALTERNATIVE_CGW_URL,
+        alternative_cgw_flush_token=settings.ALTERNATIVE_CGW_FLUSH_TOKEN,
         json={"invalidate": "Chains"},
     )
 

--- a/src/chains/tests/test_signals.py
+++ b/src/chains/tests/test_signals.py
@@ -304,9 +304,7 @@ class WalletHookTestCase(TestCase):
 
 @override_settings(
     CGW_URL="http://127.0.0.1",
-    ALTERNATIVE_CGW_URL="http://alternative.cgw.url",
     CGW_FLUSH_TOKEN="example-token",
-    ALTERNATIVE_CGW_FLUSH_TOKEN="alternative-token",
 )
 class GasPriceHookTestCase(TestCase):
     def setUp(self) -> None:
@@ -327,34 +325,16 @@ class GasPriceHookTestCase(TestCase):
                 responses.matchers.json_params_matcher({"invalidate": "Chains"}),
             ],
         )
-        responses.add(
-            responses.POST,
-            "http://alternative.cgw.url/v2/flush",
-            status=200,
-            match=[
-                responses.matchers.header_matcher(
-                    {"Authorization": "Basic alternative-token"}
-                ),
-                responses.matchers.json_params_matcher({"invalidate": "Chains"}),
-            ],
-        )
 
         GasPriceFactory.create(chain=self.chain)
 
-        assert len(responses.calls) == 2
+        assert len(responses.calls) == 1
         assert isinstance(responses.calls[0], responses.Call)
         assert responses.calls[0].request.body == b'{"invalidate": "Chains"}'
         assert responses.calls[0].request.url == "http://127.0.0.1/v2/flush"
         assert (
             responses.calls[0].request.headers.get("Authorization")
             == "Basic example-token"
-        )
-        assert isinstance(responses.calls[1], responses.Call)
-        assert responses.calls[1].request.body == b'{"invalidate": "Chains"}'
-        assert responses.calls[1].request.url == "http://alternative.cgw.url/v2/flush"
-        assert (
-            responses.calls[1].request.headers.get("Authorization")
-            == "Basic alternative-token"
         )
 
     @responses.activate

--- a/src/chains/tests/test_signals.py
+++ b/src/chains/tests/test_signals.py
@@ -7,7 +7,9 @@ from chains.tests.factories import ChainFactory, GasPriceFactory
 
 @override_settings(
     CGW_URL="http://127.0.0.1",
+    ALTERNATIVE_CGW_URL="http://alternative.cgw.url",
     CGW_FLUSH_TOKEN="example-token",
+    ALTERNATIVE_CGW_FLUSH_TOKEN="alternative-token",
 )
 class ChainNetworkHookTestCase(TestCase):
     @responses.activate
@@ -23,16 +25,34 @@ class ChainNetworkHookTestCase(TestCase):
                 responses.matchers.json_params_matcher({"invalidate": "Chains"}),
             ],
         )
+        responses.add(
+            responses.POST,
+            "http://alternative.cgw.url/v2/flush",
+            status=200,
+            match=[
+                responses.matchers.header_matcher(
+                    {"Authorization": "Basic alternative-token"}
+                ),
+                responses.matchers.json_params_matcher({"invalidate": "Chains"}),
+            ],
+        )
 
         ChainFactory.create()
 
-        assert len(responses.calls) == 1
+        assert len(responses.calls) == 2
         assert isinstance(responses.calls[0], responses.Call)
         assert responses.calls[0].request.body == b'{"invalidate": "Chains"}'
         assert responses.calls[0].request.url == "http://127.0.0.1/v2/flush"
         assert (
             responses.calls[0].request.headers.get("Authorization")
             == "Basic example-token"
+        )
+        assert isinstance(responses.calls[1], responses.Call)
+        assert responses.calls[1].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[1].request.url == "http://alternative.cgw.url/v2/flush"
+        assert (
+            responses.calls[1].request.headers.get("Authorization")
+            == "Basic alternative-token"
         )
 
     @responses.activate
@@ -48,10 +68,21 @@ class ChainNetworkHookTestCase(TestCase):
                 responses.matchers.json_params_matcher({"invalidate": "Chains"}),
             ],
         )
+        responses.add(
+            responses.POST,
+            "http://alternative.cgw.url/v2/flush",
+            status=400,
+            match=[
+                responses.matchers.header_matcher(
+                    {"Authorization": "Basic alternative-token"}
+                ),
+                responses.matchers.json_params_matcher({"invalidate": "Chains"}),
+            ],
+        )
 
         ChainFactory.create()
 
-        assert len(responses.calls) == 1
+        assert len(responses.calls) == 2
 
     @responses.activate
     def test_on_chain_update_hook_500(self) -> None:
@@ -66,10 +97,21 @@ class ChainNetworkHookTestCase(TestCase):
                 responses.matchers.json_params_matcher({"invalidate": "Chains"}),
             ],
         )
+        responses.add(
+            responses.POST,
+            "http://alternative.cgw.url/v2/flush",
+            status=500,
+            match=[
+                responses.matchers.header_matcher(
+                    {"Authorization": "Basic alternative-token"}
+                ),
+                responses.matchers.json_params_matcher({"invalidate": "Chains"}),
+            ],
+        )
 
         ChainFactory.create()
 
-        assert len(responses.calls) == 1
+        assert len(responses.calls) == 2
 
     @responses.activate
     def test_on_chain_delete_hook_call(self) -> None:
@@ -93,7 +135,9 @@ class ChainNetworkHookTestCase(TestCase):
 
     @override_settings(
         CGW_URL=None,
+        ALTERNATIVE_CGW_URL="http://alternative.cgw.url",
         CGW_FLUSH_TOKEN=None,
+        ALTERNATIVE_CGW_FLUSH_TOKEN="alternative-token",
     )
     @responses.activate
     def test_on_chain_update_with_no_cgw_set(self) -> None:
@@ -103,7 +147,9 @@ class ChainNetworkHookTestCase(TestCase):
 
     @override_settings(
         CGW_URL="http://127.0.0.1",
+        ALTERNATIVE_CGW_URL="http://alternative.cgw.url",
         CGW_FLUSH_TOKEN=None,
+        ALTERNATIVE_CGW_FLUSH_TOKEN="alternative-token",
     )
     @responses.activate
     def test_on_chain_update_with_no_flush_token_set(self) -> None:
@@ -114,7 +160,9 @@ class ChainNetworkHookTestCase(TestCase):
 
 @override_settings(
     CGW_URL="http://127.0.0.1",
+    ALTERNATIVE_CGW_URL="http://alternative.cgw.url",
     CGW_FLUSH_TOKEN="example-token",
+    ALTERNATIVE_CGW_FLUSH_TOKEN="alternative-token",
 )
 class FeatureHookTestCase(TestCase):
     @responses.activate
@@ -130,16 +178,34 @@ class FeatureHookTestCase(TestCase):
                 responses.matchers.json_params_matcher({"invalidate": "Chains"}),
             ],
         )
+        responses.add(
+            responses.POST,
+            "http://alternative.cgw.url/v2/flush",
+            status=200,
+            match=[
+                responses.matchers.header_matcher(
+                    {"Authorization": "Basic alternative-token"}
+                ),
+                responses.matchers.json_params_matcher({"invalidate": "Chains"}),
+            ],
+        )
 
         Feature(key="Test Feature").save()
 
-        assert len(responses.calls) == 1
+        assert len(responses.calls) == 2
         assert isinstance(responses.calls[0], responses.Call)
         assert responses.calls[0].request.body == b'{"invalidate": "Chains"}'
         assert responses.calls[0].request.url == "http://127.0.0.1/v2/flush"
         assert (
             responses.calls[0].request.headers.get("Authorization")
             == "Basic example-token"
+        )
+        assert isinstance(responses.calls[1], responses.Call)
+        assert responses.calls[1].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[1].request.url == "http://alternative.cgw.url/v2/flush"
+        assert (
+            responses.calls[1].request.headers.get("Authorization")
+            == "Basic alternative-token"
         )
 
     @responses.activate
@@ -166,7 +232,9 @@ class FeatureHookTestCase(TestCase):
 
 @override_settings(
     CGW_URL="http://127.0.0.1",
+    ALTERNATIVE_CGW_URL="http://alternative.cgw.url",
     CGW_FLUSH_TOKEN="example-token",
+    ALTERNATIVE_CGW_FLUSH_TOKEN="alternative-token",
 )
 class WalletHookTestCase(TestCase):
     @responses.activate
@@ -182,16 +250,34 @@ class WalletHookTestCase(TestCase):
                 responses.matchers.json_params_matcher({"invalidate": "Chains"}),
             ],
         )
+        responses.add(
+            responses.POST,
+            "http://alternative.cgw.url/v2/flush",
+            status=200,
+            match=[
+                responses.matchers.header_matcher(
+                    {"Authorization": "Basic alternative-token"}
+                ),
+                responses.matchers.json_params_matcher({"invalidate": "Chains"}),
+            ],
+        )
 
         Wallet(key="Test Wallet").save()
 
-        assert len(responses.calls) == 1
+        assert len(responses.calls) == 2
         assert isinstance(responses.calls[0], responses.Call)
         assert responses.calls[0].request.body == b'{"invalidate": "Chains"}'
         assert responses.calls[0].request.url == "http://127.0.0.1/v2/flush"
         assert (
             responses.calls[0].request.headers.get("Authorization")
             == "Basic example-token"
+        )
+        assert isinstance(responses.calls[1], responses.Call)
+        assert responses.calls[1].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[1].request.url == "http://alternative.cgw.url/v2/flush"
+        assert (
+            responses.calls[1].request.headers.get("Authorization")
+            == "Basic alternative-token"
         )
 
     @responses.activate
@@ -218,7 +304,9 @@ class WalletHookTestCase(TestCase):
 
 @override_settings(
     CGW_URL="http://127.0.0.1",
+    ALTERNATIVE_CGW_URL="http://alternative.cgw.url",
     CGW_FLUSH_TOKEN="example-token",
+    ALTERNATIVE_CGW_FLUSH_TOKEN="alternative-token",
 )
 class GasPriceHookTestCase(TestCase):
     def setUp(self) -> None:
@@ -239,16 +327,34 @@ class GasPriceHookTestCase(TestCase):
                 responses.matchers.json_params_matcher({"invalidate": "Chains"}),
             ],
         )
+        responses.add(
+            responses.POST,
+            "http://alternative.cgw.url/v2/flush",
+            status=200,
+            match=[
+                responses.matchers.header_matcher(
+                    {"Authorization": "Basic alternative-token"}
+                ),
+                responses.matchers.json_params_matcher({"invalidate": "Chains"}),
+            ],
+        )
 
         GasPriceFactory.create(chain=self.chain)
 
-        assert len(responses.calls) == 1
+        assert len(responses.calls) == 2
         assert isinstance(responses.calls[0], responses.Call)
         assert responses.calls[0].request.body == b'{"invalidate": "Chains"}'
         assert responses.calls[0].request.url == "http://127.0.0.1/v2/flush"
         assert (
             responses.calls[0].request.headers.get("Authorization")
             == "Basic example-token"
+        )
+        assert isinstance(responses.calls[1], responses.Call)
+        assert responses.calls[1].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[1].request.url == "http://alternative.cgw.url/v2/flush"
+        assert (
+            responses.calls[1].request.headers.get("Authorization")
+            == "Basic alternative-token"
         )
 
     @responses.activate

--- a/src/clients/safe_client_gateway.py
+++ b/src/clients/safe_client_gateway.py
@@ -30,17 +30,18 @@ def flush(
     if cgw_flush_token is None:
         logger.error("CGW_FLUSH_TOKEN is not set. Skipping hook call")
         return
-    if (alternative_cgw_url is not None) and (alternative_cgw_flush_token is None):
-        logger.error(
-            "ALTERNATIVE_CGW_FLUSH_TOKEN is not set. Skipping alternative hook call"
-        )
 
-    urls = [cgw_url, alternative_cgw_url]
-    flush_urls = list(map(lambda url: urljoin(url, "/v2/flush"), urls))
-    flush_tokens = [cgw_flush_token, alternative_cgw_flush_token]
+    targets = [cgw_url]
+    tokens = [cgw_flush_token]
+
+    if alternative_cgw_url is not None and alternative_cgw_flush_token is not None:
+        targets.append(alternative_cgw_url)
+        tokens.append(alternative_cgw_flush_token)
+
+    urls = list(map(lambda url: urljoin(url, "/v2/flush"), targets))
 
     try:
-        for url, token in zip(flush_urls, flush_tokens):
+        for url, token in zip(urls, tokens):
             post = setup_session().post(
                 url,
                 json=json,

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -200,7 +200,9 @@ CORS_ALLOW_ALL_ORIGINS = True
 CORS_URLS_REGEX = r"^/api/.*$"
 
 CGW_URL = os.environ.get("CGW_URL")
+ALTERNATIVE_CGW_URL = os.environ.get("ALTERNATIVE_CGW_URL")
 CGW_FLUSH_TOKEN = os.environ.get("CGW_FLUSH_TOKEN")
+ALTERNATIVE_CGW_FLUSH_TOKEN = os.environ.get("ALTERNATIVE_CGW_FLUSH_TOKEN")
 
 # By default, Django stores files locally, using the MEDIA_ROOT and MEDIA_URL settings.
 # (using the default the default FileSystemStorage)

--- a/src/safe_apps/signals.py
+++ b/src/safe_apps/signals.py
@@ -17,6 +17,8 @@ def _flush_cgw_safe_apps() -> None:
     clients.safe_client_gateway.flush(
         cgw_url=settings.CGW_URL,
         cgw_flush_token=settings.CGW_FLUSH_TOKEN,
+        alternative_cgw_url=settings.ALTERNATIVE_CGW_URL,
+        alternative_cgw_flush_token=settings.ALTERNATIVE_CGW_FLUSH_TOKEN,
         # Even though the payload is Chains, it actually invalidates all the safe-config related cache
         json={"invalidate": "Chains"},
     )

--- a/src/safe_apps/tests/test_signals.py
+++ b/src/safe_apps/tests/test_signals.py
@@ -7,7 +7,9 @@ from safe_apps.tests.factories import ProviderFactory
 
 @override_settings(
     CGW_URL="http://127.0.0.1",
+    ALTERNATIVE_CGW_URL="http://alternative.cgw.url",
     CGW_FLUSH_TOKEN="example-token",
+    ALTERNATIVE_CGW_FLUSH_TOKEN="alternative-token",
 )
 class SafeAppHookTestCase(TestCase):
     @responses.activate
@@ -23,16 +25,34 @@ class SafeAppHookTestCase(TestCase):
                 responses.matchers.json_params_matcher({"invalidate": "Chains"}),
             ],
         )
+        responses.add(
+            responses.POST,
+            "http://alternative.cgw.url/v2/flush",
+            status=200,
+            match=[
+                responses.matchers.header_matcher(
+                    {"Authorization": "Basic alternative-token"}
+                ),
+                responses.matchers.json_params_matcher({"invalidate": "Chains"}),
+            ],
+        )
 
         SafeApp(app_id=1, chain_ids=[1]).save()
 
-        assert len(responses.calls) == 1
+        assert len(responses.calls) == 2
         assert isinstance(responses.calls[0], responses.Call)
         assert responses.calls[0].request.body == b'{"invalidate": "Chains"}'
         assert responses.calls[0].request.url == "http://127.0.0.1/v2/flush"
         assert (
             responses.calls[0].request.headers.get("Authorization")
             == "Basic example-token"
+        )
+        assert isinstance(responses.calls[1], responses.Call)
+        assert responses.calls[1].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[1].request.url == "http://alternative.cgw.url/v2/flush"
+        assert (
+            responses.calls[1].request.headers.get("Authorization")
+            == "Basic alternative-token"
         )
 
     @responses.activate
@@ -48,19 +68,37 @@ class SafeAppHookTestCase(TestCase):
                 responses.matchers.json_params_matcher({"invalidate": "Chains"}),
             ],
         )
+        responses.add(
+            responses.POST,
+            "http://alternative.cgw.url/v2/flush",
+            status=200,
+            match=[
+                responses.matchers.header_matcher(
+                    {"Authorization": "Basic alternative-token"}
+                ),
+                responses.matchers.json_params_matcher({"invalidate": "Chains"}),
+            ],
+        )
 
         safe_app = SafeApp(app_id=1, chain_ids=[1])
         safe_app.save()  # create
         safe_app.name = "Test app"
         safe_app.save()  # update
 
-        assert len(responses.calls) == 2
+        assert len(responses.calls) == 4
+        assert isinstance(responses.calls[0], responses.Call)
+        assert responses.calls[0].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[0].request.url == "http://127.0.0.1/v2/flush"
+        assert (
+            responses.calls[0].request.headers.get("Authorization")
+            == "Basic example-token"
+        )
         assert isinstance(responses.calls[1], responses.Call)
         assert responses.calls[1].request.body == b'{"invalidate": "Chains"}'
-        assert responses.calls[1].request.url == "http://127.0.0.1/v2/flush"
+        assert responses.calls[1].request.url == "http://alternative.cgw.url/v2/flush"
         assert (
             responses.calls[1].request.headers.get("Authorization")
-            == "Basic example-token"
+            == "Basic alternative-token"
         )
 
     @responses.activate
@@ -76,24 +114,44 @@ class SafeAppHookTestCase(TestCase):
                 responses.matchers.json_params_matcher({"invalidate": "Chains"}),
             ],
         )
+        responses.add(
+            responses.POST,
+            "http://alternative.cgw.url/v2/flush",
+            status=200,
+            match=[
+                responses.matchers.header_matcher(
+                    {"Authorization": "Basic alternative-token"}
+                ),
+                responses.matchers.json_params_matcher({"invalidate": "Chains"}),
+            ],
+        )
 
         safe_app = SafeApp(app_id=1, chain_ids=[1])
         safe_app.save()  # create
         safe_app.delete()  # delete
 
-        assert len(responses.calls) == 2
+        assert len(responses.calls) == 4
+        assert isinstance(responses.calls[0], responses.Call)
+        assert responses.calls[0].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[0].request.url == "http://127.0.0.1/v2/flush"
+        assert (
+            responses.calls[0].request.headers.get("Authorization")
+            == "Basic example-token"
+        )
         assert isinstance(responses.calls[1], responses.Call)
         assert responses.calls[1].request.body == b'{"invalidate": "Chains"}'
-        assert responses.calls[1].request.url == "http://127.0.0.1/v2/flush"
+        assert responses.calls[1].request.url == "http://alternative.cgw.url/v2/flush"
         assert (
             responses.calls[1].request.headers.get("Authorization")
-            == "Basic example-token"
+            == "Basic alternative-token"
         )
 
 
 @override_settings(
     CGW_URL="http://127.0.0.1",
+    ALTERNATIVE_CGW_URL="http://alternative.cgw.url",
     CGW_FLUSH_TOKEN="example-token",
+    ALTERNATIVE_CGW_FLUSH_TOKEN="alternative-token",
 )
 class ProviderHookTestCase(TestCase):
     @responses.activate
@@ -109,10 +167,28 @@ class ProviderHookTestCase(TestCase):
                 responses.matchers.json_params_matcher({"invalidate": "Chains"}),
             ],
         )
+        responses.add(
+            responses.POST,
+            "http://alternative.cgw.url/v2/flush",
+            status=200,
+            match=[
+                responses.matchers.header_matcher(
+                    {"Authorization": "Basic alternative-token"}
+                ),
+                responses.matchers.json_params_matcher({"invalidate": "Chains"}),
+            ],
+        )
 
         ProviderFactory.create()
 
-        assert len(responses.calls) == 1
+        assert len(responses.calls) == 2
+        assert isinstance(responses.calls[0], responses.Call)
+        assert responses.calls[0].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[0].request.url == "http://127.0.0.1/v2/flush"
+        assert (
+            responses.calls[0].request.headers.get("Authorization")
+            == "Basic example-token"
+        )
         assert isinstance(responses.calls[0], responses.Call)
         assert responses.calls[0].request.body == b'{"invalidate": "Chains"}'
         assert responses.calls[0].request.url == "http://127.0.0.1/v2/flush"
@@ -134,18 +210,36 @@ class ProviderHookTestCase(TestCase):
                 responses.matchers.json_params_matcher({"invalidate": "Chains"}),
             ],
         )
+        responses.add(
+            responses.POST,
+            "http://alternative.cgw.url/v2/flush",
+            status=200,
+            match=[
+                responses.matchers.header_matcher(
+                    {"Authorization": "Basic alternative-token"}
+                ),
+                responses.matchers.json_params_matcher({"invalidate": "Chains"}),
+            ],
+        )
 
         provider = ProviderFactory.create()  # create
         provider.name = "Test Provider"
         provider.save()  # update
 
-        assert len(responses.calls) == 2
+        assert len(responses.calls) == 4
+        assert isinstance(responses.calls[0], responses.Call)
+        assert responses.calls[0].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[0].request.url == "http://127.0.0.1/v2/flush"
+        assert (
+            responses.calls[0].request.headers.get("Authorization")
+            == "Basic example-token"
+        )
         assert isinstance(responses.calls[1], responses.Call)
         assert responses.calls[1].request.body == b'{"invalidate": "Chains"}'
-        assert responses.calls[1].request.url == "http://127.0.0.1/v2/flush"
+        assert responses.calls[1].request.url == "http://alternative.cgw.url/v2/flush"
         assert (
             responses.calls[1].request.headers.get("Authorization")
-            == "Basic example-token"
+            == "Basic alternative-token"
         )
 
     @responses.activate
@@ -161,23 +255,43 @@ class ProviderHookTestCase(TestCase):
                 responses.matchers.json_params_matcher({"invalidate": "Chains"}),
             ],
         )
+        responses.add(
+            responses.POST,
+            "http://alternative.cgw.url/v2/flush",
+            status=200,
+            match=[
+                responses.matchers.header_matcher(
+                    {"Authorization": "Basic alternative-token"}
+                ),
+                responses.matchers.json_params_matcher({"invalidate": "Chains"}),
+            ],
+        )
 
         provider = ProviderFactory.create()  # create
         provider.delete()  # delete
 
-        assert len(responses.calls) == 2
+        assert len(responses.calls) == 4
+        assert isinstance(responses.calls[0], responses.Call)
+        assert responses.calls[0].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[0].request.url == "http://127.0.0.1/v2/flush"
+        assert (
+            responses.calls[0].request.headers.get("Authorization")
+            == "Basic example-token"
+        )
         assert isinstance(responses.calls[1], responses.Call)
         assert responses.calls[1].request.body == b'{"invalidate": "Chains"}'
-        assert responses.calls[1].request.url == "http://127.0.0.1/v2/flush"
+        assert responses.calls[1].request.url == "http://alternative.cgw.url/v2/flush"
         assert (
             responses.calls[1].request.headers.get("Authorization")
-            == "Basic example-token"
+            == "Basic alternative-token"
         )
 
 
 @override_settings(
     CGW_URL="http://127.0.0.1",
+    ALTERNATIVE_CGW_URL="http://alternative.cgw.url",
     CGW_FLUSH_TOKEN="example-token",
+    ALTERNATIVE_CGW_FLUSH_TOKEN="alternative-token",
 )
 class TagHookTestCase(TestCase):
     @responses.activate
@@ -193,10 +307,28 @@ class TagHookTestCase(TestCase):
                 responses.matchers.json_params_matcher({"invalidate": "Chains"}),
             ],
         )
+        responses.add(
+            responses.POST,
+            "http://alternative.cgw.url/v2/flush",
+            status=200,
+            match=[
+                responses.matchers.header_matcher(
+                    {"Authorization": "Basic alternative-token"}
+                ),
+                responses.matchers.json_params_matcher({"invalidate": "Chains"}),
+            ],
+        )
 
         Tag().save()  # create
 
-        assert len(responses.calls) == 1
+        assert len(responses.calls) == 2
+        assert isinstance(responses.calls[0], responses.Call)
+        assert responses.calls[0].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[0].request.url == "http://127.0.0.1/v2/flush"
+        assert (
+            responses.calls[0].request.headers.get("Authorization")
+            == "Basic example-token"
+        )
         assert isinstance(responses.calls[0], responses.Call)
         assert responses.calls[0].request.body == b'{"invalidate": "Chains"}'
         assert responses.calls[0].request.url == "http://127.0.0.1/v2/flush"
@@ -218,19 +350,37 @@ class TagHookTestCase(TestCase):
                 responses.matchers.json_params_matcher({"invalidate": "Chains"}),
             ],
         )
+        responses.add(
+            responses.POST,
+            "http://alternative.cgw.url/v2/flush",
+            status=200,
+            match=[
+                responses.matchers.header_matcher(
+                    {"Authorization": "Basic alternative-token"}
+                ),
+                responses.matchers.json_params_matcher({"invalidate": "Chains"}),
+            ],
+        )
 
         tag = Tag()
         tag.save()  # create
         tag.name = "Test Tag"
         tag.save()  # update
 
-        assert len(responses.calls) == 2
+        assert len(responses.calls) == 4
+        assert isinstance(responses.calls[0], responses.Call)
+        assert responses.calls[0].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[0].request.url == "http://127.0.0.1/v2/flush"
+        assert (
+            responses.calls[0].request.headers.get("Authorization")
+            == "Basic example-token"
+        )
         assert isinstance(responses.calls[1], responses.Call)
         assert responses.calls[1].request.body == b'{"invalidate": "Chains"}'
-        assert responses.calls[1].request.url == "http://127.0.0.1/v2/flush"
+        assert responses.calls[1].request.url == "http://alternative.cgw.url/v2/flush"
         assert (
             responses.calls[1].request.headers.get("Authorization")
-            == "Basic example-token"
+            == "Basic alternative-token"
         )
 
     @responses.activate
@@ -246,16 +396,34 @@ class TagHookTestCase(TestCase):
                 responses.matchers.json_params_matcher({"invalidate": "Chains"}),
             ],
         )
+        responses.add(
+            responses.POST,
+            "http://alternative.cgw.url/v2/flush",
+            status=200,
+            match=[
+                responses.matchers.header_matcher(
+                    {"Authorization": "Basic alternative-token"}
+                ),
+                responses.matchers.json_params_matcher({"invalidate": "Chains"}),
+            ],
+        )
 
         tag = Tag()
         tag.save()  # create
         tag.delete()  # delete
 
-        assert len(responses.calls) == 2
+        assert len(responses.calls) == 4
+        assert isinstance(responses.calls[0], responses.Call)
+        assert responses.calls[0].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[0].request.url == "http://127.0.0.1/v2/flush"
+        assert (
+            responses.calls[0].request.headers.get("Authorization")
+            == "Basic example-token"
+        )
         assert isinstance(responses.calls[1], responses.Call)
         assert responses.calls[1].request.body == b'{"invalidate": "Chains"}'
-        assert responses.calls[1].request.url == "http://127.0.0.1/v2/flush"
+        assert responses.calls[1].request.url == "http://alternative.cgw.url/v2/flush"
         assert (
             responses.calls[1].request.headers.get("Authorization")
-            == "Basic example-token"
+            == "Basic alternative-token"
         )

--- a/src/safe_apps/tests/test_signals.py
+++ b/src/safe_apps/tests/test_signals.py
@@ -100,6 +100,20 @@ class SafeAppHookTestCase(TestCase):
             responses.calls[1].request.headers.get("Authorization")
             == "Basic alternative-token"
         )
+        assert isinstance(responses.calls[2], responses.Call)
+        assert responses.calls[2].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[2].request.url == "http://127.0.0.1/v2/flush"
+        assert (
+            responses.calls[2].request.headers.get("Authorization")
+            == "Basic example-token"
+        )
+        assert isinstance(responses.calls[3], responses.Call)
+        assert responses.calls[3].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[3].request.url == "http://alternative.cgw.url/v2/flush"
+        assert (
+            responses.calls[3].request.headers.get("Authorization")
+            == "Basic alternative-token"
+        )
 
     @responses.activate
     def test_on_safe_app_delete_hook_call(self) -> None:
@@ -143,6 +157,20 @@ class SafeAppHookTestCase(TestCase):
         assert responses.calls[1].request.url == "http://alternative.cgw.url/v2/flush"
         assert (
             responses.calls[1].request.headers.get("Authorization")
+            == "Basic alternative-token"
+        )
+        assert isinstance(responses.calls[2], responses.Call)
+        assert responses.calls[2].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[2].request.url == "http://127.0.0.1/v2/flush"
+        assert (
+            responses.calls[2].request.headers.get("Authorization")
+            == "Basic example-token"
+        )
+        assert isinstance(responses.calls[3], responses.Call)
+        assert responses.calls[3].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[3].request.url == "http://alternative.cgw.url/v2/flush"
+        assert (
+            responses.calls[3].request.headers.get("Authorization")
             == "Basic alternative-token"
         )
 
@@ -241,6 +269,20 @@ class ProviderHookTestCase(TestCase):
             responses.calls[1].request.headers.get("Authorization")
             == "Basic alternative-token"
         )
+        assert isinstance(responses.calls[2], responses.Call)
+        assert responses.calls[2].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[2].request.url == "http://127.0.0.1/v2/flush"
+        assert (
+            responses.calls[2].request.headers.get("Authorization")
+            == "Basic example-token"
+        )
+        assert isinstance(responses.calls[3], responses.Call)
+        assert responses.calls[3].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[3].request.url == "http://alternative.cgw.url/v2/flush"
+        assert (
+            responses.calls[3].request.headers.get("Authorization")
+            == "Basic alternative-token"
+        )
 
     @responses.activate
     def test_on_provider_delete_hook_call(self) -> None:
@@ -283,6 +325,20 @@ class ProviderHookTestCase(TestCase):
         assert responses.calls[1].request.url == "http://alternative.cgw.url/v2/flush"
         assert (
             responses.calls[1].request.headers.get("Authorization")
+            == "Basic alternative-token"
+        )
+        assert isinstance(responses.calls[2], responses.Call)
+        assert responses.calls[2].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[2].request.url == "http://127.0.0.1/v2/flush"
+        assert (
+            responses.calls[2].request.headers.get("Authorization")
+            == "Basic example-token"
+        )
+        assert isinstance(responses.calls[3], responses.Call)
+        assert responses.calls[3].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[3].request.url == "http://alternative.cgw.url/v2/flush"
+        assert (
+            responses.calls[3].request.headers.get("Authorization")
             == "Basic alternative-token"
         )
 
@@ -382,6 +438,20 @@ class TagHookTestCase(TestCase):
             responses.calls[1].request.headers.get("Authorization")
             == "Basic alternative-token"
         )
+        assert isinstance(responses.calls[2], responses.Call)
+        assert responses.calls[2].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[2].request.url == "http://127.0.0.1/v2/flush"
+        assert (
+            responses.calls[2].request.headers.get("Authorization")
+            == "Basic example-token"
+        )
+        assert isinstance(responses.calls[3], responses.Call)
+        assert responses.calls[3].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[3].request.url == "http://alternative.cgw.url/v2/flush"
+        assert (
+            responses.calls[3].request.headers.get("Authorization")
+            == "Basic alternative-token"
+        )
 
     @responses.activate
     def test_on_tag_delete_hook_call(self) -> None:
@@ -425,5 +495,19 @@ class TagHookTestCase(TestCase):
         assert responses.calls[1].request.url == "http://alternative.cgw.url/v2/flush"
         assert (
             responses.calls[1].request.headers.get("Authorization")
+            == "Basic alternative-token"
+        )
+        assert isinstance(responses.calls[2], responses.Call)
+        assert responses.calls[2].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[2].request.url == "http://127.0.0.1/v2/flush"
+        assert (
+            responses.calls[2].request.headers.get("Authorization")
+            == "Basic example-token"
+        )
+        assert isinstance(responses.calls[3], responses.Call)
+        assert responses.calls[3].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[3].request.url == "http://alternative.cgw.url/v2/flush"
+        assert (
+            responses.calls[3].request.headers.get("Authorization")
             == "Basic alternative-token"
         )

--- a/src/safe_apps/tests/test_signals.py
+++ b/src/safe_apps/tests/test_signals.py
@@ -217,12 +217,12 @@ class ProviderHookTestCase(TestCase):
             responses.calls[0].request.headers.get("Authorization")
             == "Basic example-token"
         )
-        assert isinstance(responses.calls[0], responses.Call)
-        assert responses.calls[0].request.body == b'{"invalidate": "Chains"}'
-        assert responses.calls[0].request.url == "http://127.0.0.1/v2/flush"
+        assert isinstance(responses.calls[1], responses.Call)
+        assert responses.calls[1].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[1].request.url == "http://alternative.cgw.url/v2/flush"
         assert (
-            responses.calls[0].request.headers.get("Authorization")
-            == "Basic example-token"
+            responses.calls[1].request.headers.get("Authorization")
+            == "Basic alternative-token"
         )
 
     @responses.activate
@@ -385,12 +385,12 @@ class TagHookTestCase(TestCase):
             responses.calls[0].request.headers.get("Authorization")
             == "Basic example-token"
         )
-        assert isinstance(responses.calls[0], responses.Call)
-        assert responses.calls[0].request.body == b'{"invalidate": "Chains"}'
-        assert responses.calls[0].request.url == "http://127.0.0.1/v2/flush"
+        assert isinstance(responses.calls[1], responses.Call)
+        assert responses.calls[1].request.body == b'{"invalidate": "Chains"}'
+        assert responses.calls[1].request.url == "http://alternative.cgw.url/v2/flush"
         assert (
-            responses.calls[0].request.headers.get("Authorization")
-            == "Basic example-token"
+            responses.calls[1].request.headers.get("Authorization")
+            == "Basic alternative-token"
         )
 
     @responses.activate


### PR DESCRIPTION
Closes #898 

This PR:
- Adds `ALTERNATIVE_CGW_URL` and `ALTERNATIVE_CGW_FLUSH_TOKEN` as environment variables to the service settings.
- If these variables are set, it makes the service execute a second HTTP request to `${ALTERNATIVE_CGW_URL}/v2/flush`, in order to invalidate the cache in a second Client Gateway pointed by that URL.
- Modifies the `test_signals` unit tests accordingly to verify the expected requests are executed.