### PR TITLE
Make MEDIA_URL configurable

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -209,7 +209,7 @@ ALTERNATIVE_CGW_FLUSH_TOKEN = os.environ.get("ALTERNATIVE_CGW_FLUSH_TOKEN")
 # https://docs.djangoproject.com/en/dev/ref/settings/#media-root
 MEDIA_ROOT = f"{BASE_DIR}/media/"
 # https://docs.djangoproject.com/en/dev/ref/settings/#media-url
-MEDIA_URL = "/media/"
+MEDIA_URL = os.getenv("MEDIA_URL", "/media/")
 
 AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID")
 AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY")


### PR DESCRIPTION
This PR:
- Adds an optional `MEDIA_URL` environment variable to be configured for the service local setup. This won't alter the behavior of the service when using S3 assets storage.