### PR TITLE
Set timeout when connecting to the CGW

### DIFF
--- a/.dev.env
+++ b/.dev.env
@@ -73,6 +73,12 @@ GUNICORN_WEB_RELOAD=false
 # The Client Gateway /flush token.
 #CGW_FLUSH_TOKEN=example-flush-token
 
+# The maximum number of retries to be done when connecting to the Safe Client Gateway
+#CGW_SESSION_MAX_RETRIES=0
+
+# The request timeout in seconds for requests done to the Safe Client Gateway
+#CGW_SESSION_TIMEOUT_SECONDS=2
+
 # What CPU and memory constraints will be added to your services? When left at
 # 0, they will happily use as much as needed.
 #DOCKER_POSTGRES_CPUS=0

--- a/src/clients/safe_client_gateway.py
+++ b/src/clients/safe_client_gateway.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional
 from urllib.parse import urljoin
 
 import requests
+from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
@@ -11,7 +12,9 @@ logger = logging.getLogger(__name__)
 @cache
 def setup_session() -> requests.Session:
     session = requests.Session()
-    adapter = requests.adapters.HTTPAdapter(max_retries=3)
+    adapter = requests.adapters.HTTPAdapter(
+        max_retries=settings.CGW_SESSION_MAX_RETRIES
+    )
     session.mount("http://", adapter)
     session.mount("https://", adapter)
     return session
@@ -33,6 +36,7 @@ def flush(
             url,
             json=json,
             headers={"Authorization": f"Basic {cgw_flush_token}"},
+            timeout=settings.CGW_SESSION_TIMEOUT_SECONDS,
         )
         post.raise_for_status()
     except Exception as error:

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -201,6 +201,8 @@ CORS_URLS_REGEX = r"^/api/.*$"
 
 CGW_URL = os.environ.get("CGW_URL")
 CGW_FLUSH_TOKEN = os.environ.get("CGW_FLUSH_TOKEN")
+CGW_SESSION_MAX_RETRIES = int(os.environ.get("CGW_SESSION_MAX_RETRIES", "0"))
+CGW_SESSION_TIMEOUT_SECONDS = int(os.environ.get("CGW_SESSION_TIMEOUT_SECONDS", "2"))
 
 # By default, Django stores files locally, using the MEDIA_ROOT and MEDIA_URL settings.
 # (using the default the default FileSystemStorage)


### PR DESCRIPTION
- Sets a timeout when connecting to the Safe Client Gateway.
- The timeout is configurable with the environment variable `CGW_SESSION_TIMEOUT_SECONDS`. If it's not set, 2 seconds will be used.
- The maximum number of retries is now configurable under `CGW_SESSION_MAX_RETRIES`. If it's not set, no retries will be made (0).