### PR TITLE
Invalidate safe apps for removed chains

### DIFF
--- a/src/safe_apps/signals.py
+++ b/src/safe_apps/signals.py
@@ -24,20 +24,15 @@ def on_safe_app_update(sender: SafeApp, instance: SafeApp, **kwargs: Any) -> Non
     logger.info("Clearing safe-apps cache")
     caches["safe-apps"].clear()
     if settings.FF_HOOK_EVENTS:
-        if instance.app_id is None:  # new SafeApp being created
-            for chain_id in instance.chain_ids:
-                hook_event(
-                    HookEvent(type=HookEvent.Type.SAFE_APPS_UPDATE, chain_id=chain_id)
-                )
-        else:  # existing SafeApp being updated
-            chain_ids = set(instance.chain_ids)
+        chain_ids = set(instance.chain_ids)
+        if instance.app_id is not None:  # existing SafeApp being updated
             previous = SafeApp.objects.filter(app_id=instance.app_id).first()
             if previous is not None:
                 chain_ids.update(previous.chain_ids)
-            for chain_id in chain_ids:
-                hook_event(
-                    HookEvent(type=HookEvent.Type.SAFE_APPS_UPDATE, chain_id=chain_id)
-                )
+        for chain_id in chain_ids:
+            hook_event(
+                HookEvent(type=HookEvent.Type.SAFE_APPS_UPDATE, chain_id=chain_id)
+            )
     else:
         flush()
 

--- a/src/safe_apps/tests/test_signals_ff_hook_events.py
+++ b/src/safe_apps/tests/test_signals_ff_hook_events.py
@@ -79,6 +79,152 @@ class SafeAppHookTestCase(TestCase):
         )
 
     @responses.activate
+    def test_on_safe_app_update_by_adding_chain_ids(self) -> None:
+        responses.add(
+            responses.POST,
+            "http://127.0.0.1/v1/hooks/events",
+            status=200,
+            match=[
+                responses.matchers.header_matcher(
+                    {"Authorization": "Basic example-token"}
+                ),
+                responses.matchers.json_params_matcher(
+                    {"type": "SAFE_APPS_UPDATE", "chainId": "1"}
+                ),
+            ],
+        )
+
+        safe_app = SafeApp(app_id=1, chain_ids=[1])
+        safe_app.save()  # create
+        safe_app.chain_ids = [1, 2, 3]
+        safe_app.save()  # update
+
+        assert len(responses.calls) == 4
+        assert isinstance(responses.calls[0], responses.Call)
+        assert (
+            responses.calls[0].request.body
+            == b'{"type": "SAFE_APPS_UPDATE", "chainId": "1"}'
+        )
+        assert responses.calls[0].request.url == "http://127.0.0.1/v1/hooks/events"
+        assert (
+            responses.calls[0].request.headers.get("Authorization")
+            == "Basic example-token"
+        )
+        assert isinstance(responses.calls[1], responses.Call)
+        assert (
+            responses.calls[1].request.body
+            == b'{"type": "SAFE_APPS_UPDATE", "chainId": "1"}'
+        )
+        assert responses.calls[1].request.url == "http://127.0.0.1/v1/hooks/events"
+        assert (
+            responses.calls[1].request.headers.get("Authorization")
+            == "Basic example-token"
+        )
+        assert isinstance(responses.calls[2], responses.Call)
+        assert (
+            responses.calls[2].request.body
+            == b'{"type": "SAFE_APPS_UPDATE", "chainId": "2"}'
+        )
+        assert responses.calls[2].request.url == "http://127.0.0.1/v1/hooks/events"
+        assert (
+            responses.calls[2].request.headers.get("Authorization")
+            == "Basic example-token"
+        )
+        assert isinstance(responses.calls[3], responses.Call)
+        assert (
+            responses.calls[3].request.body
+            == b'{"type": "SAFE_APPS_UPDATE", "chainId": "3"}'
+        )
+        assert responses.calls[3].request.url == "http://127.0.0.1/v1/hooks/events"
+        assert (
+            responses.calls[3].request.headers.get("Authorization")
+            == "Basic example-token"
+        )
+
+    @responses.activate
+    def test_on_safe_app_update_by_removing_chain_ids(self) -> None:
+        responses.add(
+            responses.POST,
+            "http://127.0.0.1/v1/hooks/events",
+            status=200,
+            match=[
+                responses.matchers.header_matcher(
+                    {"Authorization": "Basic example-token"}
+                ),
+                responses.matchers.json_params_matcher(
+                    {"type": "SAFE_APPS_UPDATE", "chainId": "1"}
+                ),
+            ],
+        )
+
+        safe_app = SafeApp(app_id=1, chain_ids=[1, 2, 3])
+        safe_app.save()  # create
+        safe_app.chain_ids = [1]
+        safe_app.save()  # update
+
+        assert len(responses.calls) == 6
+        assert isinstance(responses.calls[0], responses.Call)
+        assert (
+            responses.calls[0].request.body
+            == b'{"type": "SAFE_APPS_UPDATE", "chainId": "1"}'
+        )
+        assert responses.calls[0].request.url == "http://127.0.0.1/v1/hooks/events"
+        assert (
+            responses.calls[0].request.headers.get("Authorization")
+            == "Basic example-token"
+        )
+        assert isinstance(responses.calls[1], responses.Call)
+        assert (
+            responses.calls[1].request.body
+            == b'{"type": "SAFE_APPS_UPDATE", "chainId": "2"}'
+        )
+        assert responses.calls[1].request.url == "http://127.0.0.1/v1/hooks/events"
+        assert (
+            responses.calls[1].request.headers.get("Authorization")
+            == "Basic example-token"
+        )
+        assert isinstance(responses.calls[2], responses.Call)
+        assert (
+            responses.calls[2].request.body
+            == b'{"type": "SAFE_APPS_UPDATE", "chainId": "3"}'
+        )
+        assert responses.calls[2].request.url == "http://127.0.0.1/v1/hooks/events"
+        assert (
+            responses.calls[2].request.headers.get("Authorization")
+            == "Basic example-token"
+        )
+        assert isinstance(responses.calls[3], responses.Call)
+        assert (
+            responses.calls[3].request.body
+            == b'{"type": "SAFE_APPS_UPDATE", "chainId": "1"}'
+        )
+        assert responses.calls[3].request.url == "http://127.0.0.1/v1/hooks/events"
+        assert (
+            responses.calls[3].request.headers.get("Authorization")
+            == "Basic example-token"
+        )
+        assert isinstance(responses.calls[4], responses.Call)
+        assert (
+            responses.calls[4].request.body
+            == b'{"type": "SAFE_APPS_UPDATE", "chainId": "2"}'
+        )
+        assert responses.calls[4].request.url == "http://127.0.0.1/v1/hooks/events"
+        assert (
+            responses.calls[4].request.headers.get("Authorization")
+            == "Basic example-token"
+        )
+        assert isinstance(responses.calls[5], responses.Call)
+        assert (
+            responses.calls[5].request.body
+            == b'{"type": "SAFE_APPS_UPDATE", "chainId": "3"}'
+        )
+        assert responses.calls[5].request.url == "http://127.0.0.1/v1/hooks/events"
+        assert (
+            responses.calls[5].request.headers.get("Authorization")
+            == "Basic example-token"
+        )
+
+    @responses.activate
     def test_on_safe_app_delete(self) -> None:
         responses.add(
             responses.POST,


### PR DESCRIPTION
Closes https://github.com/safe-global/safe-client-gateway/issues/1005

**Problem:**
When the `Chains` related to a `SafeApp` configuration change, hooks of type `SAFE_APPS_UPDATE` are dispatched for each chain involved. This is true when the `SafeApp` is created, and also for the `Chain` items linked after the `SafeApp` update, but right now no hook is dispatched for the `Chain` items being unlinked by the update operation.

**Changes:**
- Decouples `post_delete` signal from the affected flow, as it remains as it is.
- Change the handling of `post_save` signal to handle `pre_save` signal, to have access to the instance's `Chain` list before the update is made.
- Both the `Chain` items related to the `SafeApp` before and after the update are stored in a `Set` to avoid repetitions. Hooks are dispatched for all the `Chain` items in the set.