### PR TITLE
Rename CGW_FLUSH_TOKEN to CGW_AUTH_TOKEN

### DIFF
--- a/.dev.env
+++ b/.dev.env
@@ -70,8 +70,8 @@ GUNICORN_WEB_RELOAD=false
 # The Client Gateway URL. This is for triggering webhooks to invalidate its cache for example
 #CGW_URL=http://127.0.0.1
 
-# The Client Gateway /flush token.
-#CGW_FLUSH_TOKEN=example-flush-token
+# The Client Gateway /v1/hooks/events token.
+#CGW_AUTH_TOKEN=example-auth-token
 
 # The maximum number of retries to be done when connecting to the Safe Client Gateway
 #CGW_SESSION_MAX_RETRIES=0

--- a/src/chains/tests/test_signals.py
+++ b/src/chains/tests/test_signals.py
@@ -11,21 +11,21 @@ Faker.seed(0)
 
 class ChainNetworkHookTestCaseSetupCheck(TestCase):
     @responses.activate
-    @override_settings(CGW_URL=None, CGW_FLUSH_TOKEN="example-token")
+    @override_settings(CGW_URL=None, CGW_AUTH_TOKEN="example-token")
     def test_no_cgw_call_with_no_url(self) -> None:
         ChainFactory.create()
 
         assert len(responses.calls) == 0
 
     @responses.activate
-    @override_settings(CGW_URL="http://127.0.0.1", CGW_FLUSH_TOKEN=None)
+    @override_settings(CGW_URL="http://127.0.0.1", CGW_AUTH_TOKEN=None)
     def test_no_cgw_call_with_no_token(self) -> None:
         ChainFactory.create()
 
         assert len(responses.calls) == 0
 
 
-@override_settings(CGW_URL="http://127.0.0.1", CGW_FLUSH_TOKEN="example-token")
+@override_settings(CGW_URL="http://127.0.0.1", CGW_AUTH_TOKEN="example-token")
 class ChainNetworkHookTestCase(TestCase):
     @responses.activate
     def test_on_chain_create(self) -> None:
@@ -117,7 +117,7 @@ class ChainNetworkHookTestCase(TestCase):
         )
 
 
-@override_settings(CGW_URL="http://127.0.0.1", CGW_FLUSH_TOKEN="example-token")
+@override_settings(CGW_URL="http://127.0.0.1", CGW_AUTH_TOKEN="example-token")
 class FeatureHookTestCase(TestCase):
     @responses.activate
     def test_on_feature_create_with_no_chain(self) -> None:
@@ -243,7 +243,7 @@ class FeatureHookTestCase(TestCase):
         )
 
 
-@override_settings(CGW_URL="http://127.0.0.1", CGW_FLUSH_TOKEN="example-token")
+@override_settings(CGW_URL="http://127.0.0.1", CGW_AUTH_TOKEN="example-token")
 class WalletHookTestCase(TestCase):
     @responses.activate
     def test_on_wallet_create_with_no_chain(self) -> None:
@@ -369,7 +369,7 @@ class WalletHookTestCase(TestCase):
         )
 
 
-@override_settings(CGW_URL="http://127.0.0.1", CGW_FLUSH_TOKEN="example-token")
+@override_settings(CGW_URL="http://127.0.0.1", CGW_AUTH_TOKEN="example-token")
 class GasPriceHookTestCase(TestCase):
     def setUp(self) -> None:
         self.chain = (

--- a/src/clients/safe_client_gateway.py
+++ b/src/clients/safe_client_gateway.py
@@ -35,9 +35,9 @@ def setup_session() -> requests.Session:
 def cgw_setup() -> tuple[str, str]:
     if settings.CGW_URL is None:
         raise ValueError("CGW_URL is not set. Skipping hook call")
-    if settings.CGW_FLUSH_TOKEN is None:
-        raise ValueError("CGW_FLUSH_TOKEN is not set. Skipping hook call")
-    return (settings.CGW_URL, settings.CGW_FLUSH_TOKEN)
+    if settings.CGW_AUTH_TOKEN is None:
+        raise ValueError("CGW_AUTH_TOKEN is not set. Skipping hook call")
+    return (settings.CGW_URL, settings.CGW_AUTH_TOKEN)
 
 
 def hook_event(event: HookEvent) -> None:

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -199,7 +199,7 @@ CORS_ALLOW_ALL_ORIGINS = True
 CORS_URLS_REGEX = r"^/api/.*$"
 
 CGW_URL = os.environ.get("CGW_URL")
-CGW_FLUSH_TOKEN = os.environ.get("CGW_FLUSH_TOKEN")
+CGW_AUTH_TOKEN = os.environ.get("CGW_AUTH_TOKEN")
 CGW_SESSION_MAX_RETRIES = int(os.environ.get("CGW_SESSION_MAX_RETRIES", "0"))
 CGW_SESSION_TIMEOUT_SECONDS = int(os.environ.get("CGW_SESSION_TIMEOUT_SECONDS", "2"))
 

--- a/src/safe_apps/tests/test_signals.py
+++ b/src/safe_apps/tests/test_signals.py
@@ -9,7 +9,7 @@ fake = Faker()
 Faker.seed(0)
 
 
-@override_settings(CGW_URL="http://127.0.0.1", CGW_FLUSH_TOKEN="example-token")
+@override_settings(CGW_URL="http://127.0.0.1", CGW_AUTH_TOKEN="example-token")
 class SafeAppHookTestCase(TestCase):
     @responses.activate
     def test_on_safe_app_create(self) -> None:
@@ -253,7 +253,7 @@ class SafeAppHookTestCase(TestCase):
         )
 
 
-@override_settings(CGW_URL="http://127.0.0.1", CGW_FLUSH_TOKEN="example-token")
+@override_settings(CGW_URL="http://127.0.0.1", CGW_AUTH_TOKEN="example-token")
 class ProviderHookTestCase(TestCase):
     @responses.activate
     def test_on_provider_create_with_no_safe_app(self) -> None:
@@ -334,7 +334,7 @@ class ProviderHookTestCase(TestCase):
         )
 
 
-@override_settings(CGW_URL="http://127.0.0.1", CGW_FLUSH_TOKEN="example-token")
+@override_settings(CGW_URL="http://127.0.0.1", CGW_AUTH_TOKEN="example-token")
 class TagHookTestCase(TestCase):
     @responses.activate
     def test_on_tag_create_with_no_safe_app(self) -> None:
@@ -446,7 +446,7 @@ class TagHookTestCase(TestCase):
         )
 
 
-@override_settings(CGW_URL="http://127.0.0.1", CGW_FLUSH_TOKEN="example-token")
+@override_settings(CGW_URL="http://127.0.0.1", CGW_AUTH_TOKEN="example-token")
 class FeatureHookTestCase(TestCase):
     @responses.activate
     def test_on_feature_create_with_no_safe_app(self) -> None:


### PR DESCRIPTION
Depends on #1026 

Changes:
- Renames `CGW_FLUSH_TOKEN` to `CGW_AUTH_TOKEN` on several files.
