### PR TITLE
Fix Chain Logo URI database migration

### DIFF
--- a/src/chains/migrations/0040_chain_chain_logo_uri.py
+++ b/src/chains/migrations/0040_chain_chain_logo_uri.py
@@ -16,6 +16,7 @@ class Migration(migrations.Migration):
             name="chain_logo_uri",
             field=models.ImageField(
                 default=None,
+                null=True,
                 max_length=255,
                 upload_to=chains.models.chain_logo_path,
                 validators=[chains.models.validate_native_currency_size],


### PR DESCRIPTION
### Changes:
- Sets the `chain_logo_uri` field as nullable on `0040_chain_chain_logo_uri.py` migration.