### PR TITLE
Introduce USE_PROXY_SSL_HEADER environment variable

### DIFF
--- a/.dev.env
+++ b/.dev.env
@@ -118,3 +118,7 @@ DEFAULT_FILE_STORAGE=django.core.files.storage.FileSystemStorage
 CSRF_TRUSTED_ORIGINS="http://localhost:${NGINX_HOST_PORT}"
 #CSRF_TRUSTED_ORIGINS="https://safe-config.staging.gnosisdev.com,http://safe-config.staging.gnosisdev.com"
 #CSRF_TRUSTED_ORIGINS="https://safe-config.gnosis.io,http://safe-config.gnosis.io"
+
+# Enable this environment variable if your app is behind a proxy to use the `HTTP_X_FORWARDED_PROTO` header
+# for secure request detection (HTTPS).
+# USE_PROXY_SSL_HEADER=true

--- a/.dev.env
+++ b/.dev.env
@@ -121,4 +121,5 @@ CSRF_TRUSTED_ORIGINS="http://localhost:${NGINX_HOST_PORT}"
 
 # Enable this environment variable if your app is behind a proxy to use the `HTTP_X_FORWARDED_PROTO` header
 # for secure request detection (HTTPS).
+# See https://docs.djangoproject.com/en/dev/ref/settings/#secure-proxy-ssl-header
 # USE_PROXY_SSL_HEADER=true

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -235,3 +235,7 @@ if allowed_csrf_origins:
         allowed_csrf_origins.strip()
         for allowed_csrf_origins in allowed_csrf_origins.split(",")
     ]
+
+use_proxy_ssl_header = os.environ.get("USE_PROXY_SSL_HEADER", "false").lower() == "true"
+if use_proxy_ssl_header:
+    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")


### PR DESCRIPTION
## Summary
This PR introduces `USE_PROXY_SSL_HEADER` environment variable to the project.

When set to `true`, this variable enables the use of the `HTTP_X_FORWARDED_PROTO` header for secure request detection in case the application is behind a proxy. This helps control Django's `is_secure()` method behavior, in scenarios where SSL termination occurs at the proxy level.

## Changes:

- [x] added `USE_PROXY_SSL_HEADER` to the `.dev.env` file with documentation.
- [x] update `settings.py` file to conditionally set `SECURE_PROXY_SSL_HEADER` settings.

These changes are backward compatible and should not affect existing deployments unless the environment variable is explicitly set.

## Links
- Reported Issue: https://github.com/safe-global/safe-config-service/issues/634
- Django: https://docs.djangoproject.com/en/5.0/ref/settings/#secure-proxy-ssl-header