### PR TITLE
Bumps Flake8 version in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,6 @@ repos:
       - id: black
         language_version: python3
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 7.0.0
     hooks:
       - id: flake8


### PR DESCRIPTION
- The pre-commit configuration was using Flake8 version 6.0.0 while the project version is 7.0.0.
- This led to a mismatch of linter errors for environments using the pre-commit setup and the ones not using it (e.g., GitHub Actions).