### PR TITLE
fix: handle 0 as fixed gas fee

### DIFF
--- a/src/chains/serializers.py
+++ b/src/chains/serializers.py
@@ -37,7 +37,7 @@ class GasPriceSerializer(serializers.Serializer[GasPrice]):
         ):
             return GasPriceOracleSerializer(instance).data
         elif (
-            instance.fixed_wei_value
+            instance.fixed_wei_value is not None
             and instance.oracle_uri is None
             and instance.max_fee_per_gas is None
             and instance.max_priority_fee_per_gas is None

--- a/src/chains/tests/test_models.py
+++ b/src/chains/tests/test_models.py
@@ -148,6 +148,18 @@ class ChainGasPriceOracleTestCase(TestCase):
         with self.assertRaises(ValidationError):
             gas_price.full_clean()
 
+    def test_zero_oracle_gas_parameter_with_null_uri(self) -> None:
+        gas_price = GasPriceFactory.create(
+            fixed_wei_value=0,
+            oracle_uri=None,
+            oracle_parameter=None,
+            max_fee_per_gas=None,
+            max_priority_fee_per_gas=None,
+        )
+
+        # No validation exception should be thrown
+        gas_price.full_clean()
+
     def test_oracle_gas_parameter_with_uri(self) -> None:
         gas_price = GasPriceFactory.create(
             oracle_uri=self.faker.url(),


### PR DESCRIPTION
## Issue

For Free gas networks like GoQuorum, we need `fixed_wei_value` to be set to zero. However, the serializer check doesnt handle 0 for fixed types & raises `APIException` exception.

```sql
postgres=# select * from chains_gasprice;
-[ RECORD 1 ]------------+------------
id                       | 1
oracle_uri               | 
oracle_parameter         | 
gwei_factor              | 1.000000000
fixed_wei_value          | 0
rank                     | 100
chain_id                 | 
max_fee_per_gas          | 
max_priority_fee_per_gas | 
```

`/api/v1/chains/:chainId/`

```json
{ "detail":"The gas price oracle or a fixed gas price was not provided for chain" }
```

## Fix

This PR modifies the check to `is not None` to allow for zero values

`/api/v1/chains/:chainId/`

```json
{
    ...,
    "gasPrice": [
       {
             "type": "fixed",
             "weiValue": "0"
        }
    ],
}
```