### PR TITLE
Fix invalid iconUrl on Safe App creation

### DIFF
--- a/src/safe_apps/models.py
+++ b/src/safe_apps/models.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 from enum import Enum
 from typing import IO, Union
 
@@ -17,12 +18,7 @@ _HOSTNAME_VALIDATOR = RegexValidator(
 
 def safe_app_icon_path(instance: "SafeApp", filename: str) -> str:
     _, file_extension = os.path.splitext(filename)
-    if instance.app_id is None:  # new SafeApp, app_id is not available at this point
-        safe_apps = SafeApp.objects.all().order_by("-app_id")
-        app_id = safe_apps[0].app_id + 1 if safe_apps else 1
-        return f"safe_apps/{app_id}/icon{file_extension}"
-    else:  # existing SafeApp, app_id is available
-        return f"safe_apps/{instance.app_id}/icon{file_extension}"
+    return f"safe_apps/{uuid.uuid4()}/icon{file_extension}"
 
 
 def validate_safe_app_icon_size(image: Union[str, IO[bytes]]) -> None:

--- a/src/safe_apps/models.py
+++ b/src/safe_apps/models.py
@@ -17,7 +17,12 @@ _HOSTNAME_VALIDATOR = RegexValidator(
 
 def safe_app_icon_path(instance: "SafeApp", filename: str) -> str:
     _, file_extension = os.path.splitext(filename)
-    return f"safe_apps/{instance.app_id}/icon{file_extension}"
+    if instance.app_id is None:  # new SafeApp, app_id is not available at this point
+        safe_apps = SafeApp.objects.all().order_by("-app_id")
+        app_id = safe_apps[0].app_id + 1 if safe_apps else 1
+        return f"safe_apps/{app_id}/icon{file_extension}"
+    else:  # existing SafeApp, app_id is available
+        return f"safe_apps/{instance.app_id}/icon{file_extension}"
 
 
 def validate_safe_app_icon_size(image: Union[str, IO[bytes]]) -> None:

--- a/src/safe_apps/tests/test_models.py
+++ b/src/safe_apps/tests/test_models.py
@@ -16,9 +16,14 @@ class IconTestCase(TestCase):
     def test_icon_upload_path(self) -> None:
         safe_app = SafeAppFactory.create()
 
-        self.assertEqual(
-            safe_app.icon_url.url, f"/media/safe_apps/{safe_app.app_id}/icon.jpg"
+        path_regex = "|".join(
+            [
+                r"\/media\/safe_apps\/",
+                r"[0-9(a-f|A-F)]{8}-[0-9(a-f|A-F)]{4}-4[0-9(a-f|A-F)]{3}-[89ab][0-9(a-f|A-F)]{3}-[0-9(a-f|A-F)]{12}",
+                r"\/icon.jpg",
+            ]
         )
+        self.assertRegex(safe_app.icon_url.url, path_regex)
 
     def test_icon_max_size_validation(self) -> None:
         safe_app = SafeAppFactory.create(


### PR DESCRIPTION
Closes #1100 

## Summary
This PR fixes a bug in the `SafeApp` creation flow. As `SafeApp` is not persisted to the database yet when `safe_app_icon_path` is executed, it has no access to the `app_id` field (as it depends on the database PK). So this field cannot be used directly as part of the file URL. As a result, before this PR, `None` was being appended to the URL instead of the app ID.

## Changes
- Generate logo URLs by calling `uuid.uuid4()` instead of relying on the Safe App ID.