### PR TITLE
Add optional "onlyListed" query param for SafeApps filtering

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -28,7 +28,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = os.getenv("SECRET_KEY", "random-dev-key")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.getenv("DEBUG", "true").lower() == "true"
 
 # https://docs.djangoproject.com/en/3.2/ref/settings/#std:setting-ALLOWED_HOSTS
 allowed_hosts = os.getenv("DJANGO_ALLOWED_HOSTS", ".localhost,127.0.0.1,[::1]")

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -28,7 +28,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = os.getenv("SECRET_KEY", "random-dev-key")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.getenv("DEBUG", "true").lower() == "true"
+DEBUG = True
 
 # https://docs.djangoproject.com/en/3.2/ref/settings/#std:setting-ALLOWED_HOSTS
 allowed_hosts = os.getenv("DJANGO_ALLOWED_HOSTS", ".localhost,127.0.0.1,[::1]")

--- a/src/safe_apps/models.py
+++ b/src/safe_apps/models.py
@@ -58,6 +58,7 @@ class SafeApp(models.Model):
         DOMAIN_ALLOWLIST = "DOMAIN_ALLOWLIST"
 
     app_id = models.BigAutoField(primary_key=True)
+    # TODO: rename "visible" to "listed" across the service
     visible = models.BooleanField(
         default=True
     )  # True if this safe-app should be visible from the view. False otherwise

--- a/src/safe_apps/tests/test_views.py
+++ b/src/safe_apps/tests/test_views.py
@@ -656,7 +656,7 @@ class SafeAppsVisibilityTests(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertCountEqual(response.json(), json_response)
 
-    def test_not_visible_safe_app_is_shown_if_only_listed_is_true(self) -> None:
+    def test_not_visible_safe_app_is_shown_if_only_listed_is_not_set(self) -> None:
         not_visible_safe_app = SafeAppFactory.create(visible=False)
         visible_safe_app = SafeAppFactory.create(visible=True)
         json_response = [
@@ -693,17 +693,17 @@ class SafeAppsVisibilityTests(APITestCase):
                 "socialProfiles": [],
             },
         ]
-        url = reverse("v1:safe-apps:list") + f'{"?onlyListed=false"}'
+        url = reverse("v1:safe-apps:list")
 
         response = self.client.get(path=url, data=None, format="json")
 
         self.assertEqual(response.status_code, 200)
         self.assertCountEqual(response.json(), json_response)
 
-    def test_not_visible_safe_app_is_not_shown(self) -> None:
+    def test_not_visible_safe_app_is_not_shown_if_only_listed_is_set(self) -> None:
         SafeAppFactory.create(visible=False)
         json_response: List[Dict[str, Any]] = []
-        url = reverse("v1:safe-apps:list")
+        url = reverse("v1:safe-apps:list") + f'{"?onlyListed=true"}'
 
         response = self.client.get(path=url, data=None, format="json")
 

--- a/src/safe_apps/tests/test_views.py
+++ b/src/safe_apps/tests/test_views.py
@@ -656,7 +656,7 @@ class SafeAppsVisibilityTests(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertCountEqual(response.json(), json_response)
 
-    def test_not_visible_safe_app_is_shown_if_visibility_is_ignored(self) -> None:
+    def test_not_visible_safe_app_is_shown_if_only_listed_is_true(self) -> None:
         not_visible_safe_app = SafeAppFactory.create(visible=False)
         visible_safe_app = SafeAppFactory.create(visible=True)
         json_response = [
@@ -693,7 +693,7 @@ class SafeAppsVisibilityTests(APITestCase):
                 "socialProfiles": [],
             },
         ]
-        url = reverse("v1:safe-apps:list") + f'{"?ignoreVisibility=true"}'
+        url = reverse("v1:safe-apps:list") + f'{"?onlyListed=false"}'
 
         response = self.client.get(path=url, data=None, format="json")
 

--- a/src/safe_apps/tests/test_views.py
+++ b/src/safe_apps/tests/test_views.py
@@ -656,6 +656,50 @@ class SafeAppsVisibilityTests(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertCountEqual(response.json(), json_response)
 
+    def test_not_visible_safe_app_is_shown_if_visibility_is_ignored(self) -> None:
+        not_visible_safe_app = SafeAppFactory.create(visible=False)
+        visible_safe_app = SafeAppFactory.create(visible=True)
+        json_response = [
+            {
+                "id": not_visible_safe_app.app_id,
+                "url": not_visible_safe_app.url,
+                "name": not_visible_safe_app.name,
+                "iconUrl": f"http://testserver{not_visible_safe_app.icon_url.url}",
+                "description": not_visible_safe_app.description,
+                "chainIds": not_visible_safe_app.chain_ids,
+                "provider": None,
+                "accessControl": {
+                    "type": "NO_RESTRICTIONS",
+                },
+                "tags": [],
+                "features": [],
+                "developerWebsite": not_visible_safe_app.developer_website,
+                "socialProfiles": [],
+            },
+            {
+                "id": visible_safe_app.app_id,
+                "url": visible_safe_app.url,
+                "name": visible_safe_app.name,
+                "iconUrl": f"http://testserver{visible_safe_app.icon_url.url}",
+                "description": visible_safe_app.description,
+                "chainIds": visible_safe_app.chain_ids,
+                "provider": None,
+                "accessControl": {
+                    "type": "NO_RESTRICTIONS",
+                },
+                "tags": [],
+                "features": [],
+                "developerWebsite": visible_safe_app.developer_website,
+                "socialProfiles": [],
+            },
+        ]
+        url = reverse("v1:safe-apps:list") + f'{"?ignoreVisibility=true"}'
+
+        response = self.client.get(path=url, data=None, format="json")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertCountEqual(response.json(), json_response)
+
     def test_not_visible_safe_app_is_not_shown(self) -> None:
         SafeAppFactory.create(visible=False)
         json_response: List[Dict[str, Any]] = []

--- a/src/safe_apps/views.py
+++ b/src/safe_apps/views.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Union
 
 from django.db.models import Q, QuerySet
 from django.utils.decorators import method_decorator
@@ -11,6 +11,10 @@ from rest_framework.response import Response
 
 from .models import SafeApp
 from .serializers import SafeAppsResponseSerializer
+
+
+def parse_boolean_query_param(value: Union[bool, str, int]) -> bool:
+    return value in (True, "True", "true", "1", 1)
 
 
 class SafeAppsListView(ListAPIView):  # type: ignore[type-arg]
@@ -60,8 +64,10 @@ class SafeAppsListView(ListAPIView):  # type: ignore[type-arg]
         return super().get(request, *args, **kwargs)
 
     def get_queryset(self) -> QuerySet[SafeApp]:
-        ignore_visibility = self.request.query_params.get("ignoreVisibility")
-        if ignore_visibility == "true":
+        ignore_visibility = parse_boolean_query_param(
+            self.request.query_params.get("ignoreVisibility", False)
+        )
+        if ignore_visibility is True:
             queryset = SafeApp.objects.all()
         else:
             queryset = SafeApp.objects.filter(visible=True)

--- a/src/safe_apps/views.py
+++ b/src/safe_apps/views.py
@@ -44,7 +44,7 @@ class SafeAppsListView(ListAPIView):  # type: ignore[type-arg]
         "ignoreVisibility",
         openapi.IN_QUERY,
         description="Ignore visibility flag, including both visible and not-visible Safe Apps",
-        type=openapi.TYPE_STRING,
+        type=openapi.TYPE_BOOLEAN,
     )
 
     @method_decorator(cache_page(60 * 10, cache="safe-apps"))  # Cache 10 minutes

--- a/src/safe_apps/views.py
+++ b/src/safe_apps/views.py
@@ -40,11 +40,12 @@ class SafeAppsListView(ListAPIView):  # type: ignore[type-arg]
         type=openapi.TYPE_STRING,
     )
 
-    _swagger_ignore_visibility_param = openapi.Parameter(
-        "ignoreVisibility",
+    _swagger_only_listed_param = openapi.Parameter(
+        "onlyListed",
         openapi.IN_QUERY,
-        description="Ignore visibility flag, including both visible and not-visible Safe Apps",
+        description="If true, only listed/visible Safe Apps will be included. Else, all Safe Apps will be included",
         type=openapi.TYPE_BOOLEAN,
+        default=True,
     )
 
     @method_decorator(cache_page(60 * 10, cache="safe-apps"))  # Cache 10 minutes
@@ -53,7 +54,7 @@ class SafeAppsListView(ListAPIView):  # type: ignore[type-arg]
             _swagger_chain_id_param,
             _swagger_client_url_param,
             _swagger_url_param,
-            _swagger_ignore_visibility_param,
+            _swagger_only_listed_param,
         ]
     )  # type: ignore[misc]
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
@@ -64,10 +65,10 @@ class SafeAppsListView(ListAPIView):  # type: ignore[type-arg]
         return super().get(request, *args, **kwargs)
 
     def get_queryset(self) -> QuerySet[SafeApp]:
-        ignore_visibility = parse_boolean_query_param(
-            self.request.query_params.get("ignoreVisibility", False)
+        only_listed = parse_boolean_query_param(
+            self.request.query_params.get("onlyListed", True)
         )
-        if ignore_visibility:
+        if not only_listed:
             queryset = SafeApp.objects.all()
         else:
             queryset = SafeApp.objects.filter(visible=True)

--- a/src/safe_apps/views.py
+++ b/src/safe_apps/views.py
@@ -67,7 +67,7 @@ class SafeAppsListView(ListAPIView):  # type: ignore[type-arg]
         ignore_visibility = parse_boolean_query_param(
             self.request.query_params.get("ignoreVisibility", False)
         )
-        if ignore_visibility is True:
+        if ignore_visibility:
             queryset = SafeApp.objects.all()
         else:
             queryset = SafeApp.objects.filter(visible=True)

--- a/src/safe_apps/views.py
+++ b/src/safe_apps/views.py
@@ -45,7 +45,7 @@ class SafeAppsListView(ListAPIView):  # type: ignore[type-arg]
         openapi.IN_QUERY,
         description="If true, only listed/visible Safe Apps will be included. Else, all Safe Apps will be included",
         type=openapi.TYPE_BOOLEAN,
-        default=True,
+        default=False,
     )
 
     @method_decorator(cache_page(60 * 10, cache="safe-apps"))  # Cache 10 minutes
@@ -66,12 +66,12 @@ class SafeAppsListView(ListAPIView):  # type: ignore[type-arg]
 
     def get_queryset(self) -> QuerySet[SafeApp]:
         only_listed = parse_boolean_query_param(
-            self.request.query_params.get("onlyListed", True)
+            self.request.query_params.get("onlyListed", False)
         )
-        if not only_listed:
-            queryset = SafeApp.objects.all()
-        else:
+        if only_listed:
             queryset = SafeApp.objects.filter(visible=True)
+        else:
+            queryset = SafeApp.objects.all()
 
         chain_id = self.request.query_params.get("chainId")
         if chain_id is not None and chain_id.isdigit():


### PR DESCRIPTION
## Summary
This PR adds an optional query parameter to `/safe-apps/` endpoint to manage the visibility filter.

## Changes
- Adds `onlyListed` query parameter. When it's `false`, both `visible: true` and `visible: false` Safe Apps are returned in the endpoint response. When it's `true` only `visible: true` Safe Apps are returned.