### PR TITLE
Allow URL paths on CGW_URL

### DIFF
--- a/src/clients/safe_client_gateway.py
+++ b/src/clients/safe_client_gateway.py
@@ -43,7 +43,7 @@ def cgw_setup() -> tuple[str, str]:
 def hook_event(event: HookEvent) -> None:
     try:
         (url, token) = cgw_setup()
-        url = urljoin(url, "/v1/hooks/events")
+        url = urljoin(url.rstrip("/") + "/", "v1/hooks/events")
         post(url, token, json={"type": event.type, "chainId": str(event.chain_id)})
     except Exception as error:
         logger.error(error)


### PR DESCRIPTION
## Summary
The function `urljoin` from `urllib.parse` expect a `base` and a `url` to concat. 

As the path being concatenated to `CGW_URL` is `/v1/hooks/events`, the function `urljoin` interprets `url` as a base domain, and splits out any path it can have. This causes problems when the base URL does contain paths, as those are split out.

## Changes
- The URL being added to `CGW_URL` is now `v1/hooks/events`, and the `/` URL separator is concatenated to the `base` conditionally (to avoid separator duplications).