### PR TITLE
Revert boto3 upgrade to 1.34.158

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.35.0
+boto3==1.34.158
 Django==5.1
 django-cors-headers==4.4.0
 djangorestframework==3.15.2


### PR DESCRIPTION
## Changes
- Reverts `boto3` library upgraded on https://github.com/safe-global/safe-config-service/pull/1212 to `1.34.158`