### PR TITLE
Revert django upgrade back to 5.0.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto3==1.34.158
-Django==5.1
+Django==5.0.8
 django-cors-headers==4.4.0
 djangorestframework==3.15.2
 djangorestframework-camel-case==1.4.2


### PR DESCRIPTION
## Changes
- Reverts `django` version upgrade from https://github.com/safe-global/safe-config-service/pull/1203 back to `5.0.8`