### PR TITLE
Pin web3 to 6.20.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,9 @@ gunicorn==23.0.0
 Pillow==10.4.0
 psycopg2-binary==2.9.9
 requests==2.32.3
+
+# Without pin, safe-eth-py 5.8.0 installs >= 7 which breaks django-check job
+# >  ImportError: cannot import name 'geth_poa_middleware' from 'web3.middleware'
+# TODO: Remove when safe-eth-py updates web3 to >= 7
+# https://github.com/safe-global/safe-eth-py/pull/1315
+web3==6.20.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ psycopg2-binary==2.9.9
 requests==2.32.3
 
 # Without pin, safe-eth-py 5.8.0 installs >= 7 which breaks django-check job
-# >  ImportError: cannot import name 'geth_poa_middleware' from 'web3.middleware'
+# > ImportError: cannot import name 'geth_poa_middleware' from 'web3.middleware'
 # TODO: Remove when safe-eth-py updates web3 to >= 7
 # https://github.com/safe-global/safe-eth-py/pull/1315
 web3==6.20.2


### PR DESCRIPTION
## Summary

Our `django-check` job is currently failing after install ([example](https://github.com/safe-global/safe-config-service/actions/runs/10560766575/job/29254970812?pr=1220)). This stems from the related version of the web3 package for safe-eth-py. The offending error is:

```sh
ImportError: cannot import name 'geth_poa_middleware' from 'web3.middleware'
```

When transitioning from version 6 to 7, web3 [renamed some middleware](https://web3py.readthedocs.io/en/stable/migration.html#middleware-renaming-and-removals), including `get_poa_middleware`. Our safe-eth-py package has [yet to migrate to version 7](https://github.com/safe-global/safe-eth-py/issues/1324), however. It therefore tries to import the non-existent `get_poa_middleware`.

This pins the web3 package in accordance with the requirements of safe-eth-py.

## Changes

- Pin web3 to 6.20.2