### PR TITLE
Add install command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ In order to start the server application:
 python -m venv venv # creates a virtual environment venv in the local directory
 source venv/bin/activate
 pip install -r requirements-dev.txt
+pip install setuptools
 ```
 
 #### 2. Launch the Postgres database image


### PR DESCRIPTION
## Summary

In order to run the project locally, `setuptools` needs to be installed. This adds the command to the setup guide in the README.

## Changes

- Add `pip install setuptools` command to README.