### PR TITLE
Double `max_limit` of `Chains` pagination

### DIFF
--- a/src/chains/tests/test_views.py
+++ b/src/chains/tests/test_views.py
@@ -134,22 +134,22 @@ class ChainPaginationViewTests(APITestCase):
         self.assertEqual(len(response.json()["results"]), 20)
 
     def test_request_more_than_max_limit_should_return_max_limit(self) -> None:
-        ChainFactory.create_batch(101)
+        ChainFactory.create_batch(41)
         # requesting limit > max_limit
-        url = reverse("v1:chains:list") + f'{"?limit=101"}'
+        url = reverse("v1:chains:list") + f'{"?limit=41"}'
 
         response = self.client.get(path=url, data=None, format="json")
 
         self.assertEqual(response.status_code, 200)
         # number of items should be equal to the number of total items
-        self.assertEqual(response.json()["count"], 101)
+        self.assertEqual(response.json()["count"], 41)
         self.assertEqual(
             response.json()["next"],
-            "http://testserver/api/v1/chains/?limit=20&offset=20",
+            "http://testserver/api/v1/chains/?limit=40&offset=40",
         )
         self.assertEqual(response.json()["previous"], None)
         # returned items should still be equal to max_limit
-        self.assertEqual(len(response.json()["results"]), 20)
+        self.assertEqual(len(response.json()["results"]), 40)
 
     def test_offset_greater_than_count(self) -> None:
         ChainFactory.create_batch(21)

--- a/src/chains/views.py
+++ b/src/chains/views.py
@@ -13,7 +13,7 @@ from .serializers import ChainSerializer
 
 class ChainsPagination(LimitOffsetPagination):
     default_limit = 20
-    max_limit = 20
+    max_limit = 40
 
 
 class ChainsListView(ListAPIView):  # type: ignore[type-arg]


### PR DESCRIPTION
## Summary

The current `max_limit` of `Chains` pagination is 20. However, we now have 21 chains configured on prod. As such, this doubles the `max_limit` to 40.

Note: it was [previously reduced from 100](https://github.com/safe-global/safe-config-service/pull/395). We should investigate setting this as the `count` instead.

## Changes

- Set `max_limit` to 40
- Update tests accordingly