### PR TITLE
Store CLA signatures in org. repo.

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -25,8 +25,10 @@ jobs:
           allowlist: hectorgomezv,moisses89,luarx,fmrsabino,rmeissner,Uxio0,*bot,iamacook # may need to update this expression if we add new bots
 
           #below are the optional inputs - If the optional inputs are not given, then default values will be taken
-          #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
-          #remote-repository-name:  enter the  remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)
+          # enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
+          remote-organization-name: 'safe-global'
+          # enter the remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)
+          remote-repository-name: 'cla-signatures'
           #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
           #signed-commit-message: 'For example: $contributorName has signed the CLA in #$pullRequestNo'
           #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'


### PR DESCRIPTION
## Summary

Resolves #1266

"It is preferable to use a general CLA repo to store signatures as we do in other repos"

This changes the CLA workflow to store signatures in our respective org. repo.

## Changes

- Set `remote-organization-name` to `'safe-global'`
- Set `remote-repository-name` to `'cla-signatures'`