### PR TITLE
Fix bad CLA_ACCESS_TOKEN reference

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,9 +1,9 @@
 name: "CLA Assistant"
 on:
   issue_comment:
-    types: [ created ]
+    types: [created]
   pull_request_target:
-    types: [ opened,closed,synchronize ]
+    types: [opened, closed, synchronize]
 
 jobs:
   CLAssistant:
@@ -16,19 +16,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # the below token should have repo scope and must be manually added by you in the repository's secret
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ACCESS_TOKEN }}
         with:
-          path-to-signatures: 'signatures/version1/cla.json'
-          path-to-document: 'https://safe.global/cla'
+          path-to-signatures: "signatures/version1/cla.json"
+          path-to-document: "https://safe.global/cla"
           # branch should not be protected
-          branch: 'cla-signatures'
+          branch: "cla-signatures"
           allowlist: hectorgomezv,moisses89,luarx,fmrsabino,rmeissner,Uxio0,*bot,iamacook # may need to update this expression if we add new bots
 
           #below are the optional inputs - If the optional inputs are not given, then default values will be taken
           # enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
-          remote-organization-name: 'safe-global'
+          remote-organization-name: "safe-global"
           # enter the remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)
-          remote-repository-name: 'cla-signatures'
+          remote-repository-name: "cla-signatures"
           #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
           #signed-commit-message: 'For example: $contributorName has signed the CLA in #$pullRequestNo'
           #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'


### PR DESCRIPTION
## Changes
- Changes `PERSONAL_ACCESS_TOKEN` to `CLA_ACCESS_TOKEN` in the CLA Assistant Github Action.