### PR TITLE
Fix MEDIA_ROOT env

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -211,7 +211,7 @@ CGW_SESSION_TIMEOUT_SECONDS = int(os.environ.get("CGW_SESSION_TIMEOUT_SECONDS", 
 # By default, Django stores files locally, using the MEDIA_ROOT and MEDIA_URL settings.
 # (using the default the default FileSystemStorage)
 # https://docs.djangoproject.com/en/dev/ref/settings/#media-root
-MEDIA_ROOT = f"{BASE_DIR}/media/"
+MEDIA_ROOT = os.getenv("MEDIA_ROOT", f"{BASE_DIR}/media/")
 # https://docs.djangoproject.com/en/dev/ref/settings/#media-url
 MEDIA_URL = os.getenv("MEDIA_URL", "/media/")
 


### PR DESCRIPTION
Fixes #1454 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allows runtime configuration of file storage root.
> 
> - Update `settings.py` to read `MEDIA_ROOT` from `MEDIA_ROOT` env var with fallback to `BASE_DIR/media/`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebcd5f326bf091f9542b193376eb15530fbb3d7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->