### PR TITLE
Increase chains pagination max_limit from 40 to 100

### DIFF
--- a/src/chains/tests/test_views.py
+++ b/src/chains/tests/test_views.py
@@ -131,7 +131,7 @@ class ChainPaginationViewTests(APITestCase):
             "http://testserver/api/v1/chains/?limit=40&offset=40",
         )
         self.assertEqual(response.json()["previous"], None)
-        # returned items should be equal to max_limit
+        # returned items should be equal to default_limit
         self.assertEqual(len(response.json()["results"]), 40)
 
     def test_request_more_than_max_limit_should_return_max_limit(self) -> None:
@@ -146,11 +146,11 @@ class ChainPaginationViewTests(APITestCase):
         self.assertEqual(response.json()["count"], 101)
         self.assertEqual(
             response.json()["next"],
-            "http://testserver/api/v1/chains/?limit=40&offset=40",
+            "http://testserver/api/v1/chains/?limit=100&offset=100",
         )
         self.assertEqual(response.json()["previous"], None)
         # returned items should still be equal to max_limit
-        self.assertEqual(len(response.json()["results"]), 40)
+        self.assertEqual(len(response.json()["results"]), 100)
 
     def test_offset_greater_than_count(self) -> None:
         ChainFactory.create_batch(41)

--- a/src/chains/views.py
+++ b/src/chains/views.py
@@ -13,7 +13,7 @@ from .serializers import ChainSerializer
 
 class ChainsPagination(LimitOffsetPagination):
     default_limit = 40
-    max_limit = 40
+    max_limit = 100
 
 
 class ChainsListView(ListAPIView):  # type: ignore[type-arg]


### PR DESCRIPTION
## Summary
- Increases the `max_limit` for the chains list endpoint pagination from 40 to 100
- Updates pagination tests to reflect the new limit

CGW PR: https://github.com/safe-global/safe-client-gateway/pull/2912

## Test plan
- [ ] CI passes with updated pagination tests
- [ ] Verify `/api/v1/chains/` returns up to 100 results per page
- [ ] Verify requests with `?limit=101` are still capped at 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)