### PR TITLE
fix: broadcast CHAIN_UPDATE hook to all registered services

### DIFF
--- a/src/chains/services.py
+++ b/src/chains/services.py
@@ -1,6 +1,8 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
 import logging
 from collections.abc import Iterable
 
+from chains.models import Service
 from clients.safe_client_gateway import HookEvent, hook_event
 
 logger = logging.getLogger(__name__)
@@ -12,6 +14,25 @@ class ChainUpdateWebhookService:
         chain_ids: Iterable[int],
         service_keys: list[str] | None = None,
     ) -> None:
+        """Send CHAIN_UPDATE hook events for the given chains.
+
+        Args:
+            chain_ids: Chain IDs to notify about.
+            service_keys: Controls which services are notified:
+                - None: query all registered Service records (broadcast).
+                - []: no services — fire one hook per chain with service=None.
+                - ["WALLET_WEB", ...]: fire one hook per (chain, service_key) pair.
+        """
+        if service_keys is None:
+            service_keys = list(
+                Service.objects.values_list("key", flat=True)
+            )
+            if service_keys:
+                logger.info(
+                    "Broadcasting CHAIN_UPDATE to all %d services",
+                    len(service_keys),
+                )
+
         for chain_id in chain_ids:
             if service_keys:
                 for service_key in service_keys:
@@ -24,5 +45,8 @@ class ChainUpdateWebhookService:
                     )
             else:
                 hook_event(
-                    HookEvent(type=HookEvent.Type.CHAIN_UPDATE, chain_id=chain_id)
+                    HookEvent(
+                        type=HookEvent.Type.CHAIN_UPDATE,
+                        chain_id=chain_id,
+                    )
                 )

--- a/src/chains/signals.py
+++ b/src/chains/signals.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
 import logging
 import threading
 from typing import Any
@@ -77,7 +78,7 @@ def on_feature_changed(sender: Feature, instance: Feature, **kwargs: Any) -> Non
         # Scope changes are handled by the on_feature_scope_change_post_save signal
         return
 
-    service_keys = list(instance.services.values_list("key", flat=True)) or None
+    service_keys = list(instance.services.values_list("key", flat=True))
     chain_ids = (
         Chain.objects.values_list("id", flat=True)
         if instance.scope == Feature.Scope.GLOBAL
@@ -97,7 +98,7 @@ def on_feature_scope_change_post_save(sender: Feature, instance: Feature, **kwar
         old_scope,
         instance.scope,
     )
-    service_keys = list(instance.services.values_list("key", flat=True)) or None
+    service_keys = list(instance.services.values_list("key", flat=True))
     chain_ids = Chain.objects.values_list("id", flat=True)
     webhook_service.notify(chain_ids, service_keys)
     _clear_feature_old_scope(instance)
@@ -113,7 +114,7 @@ def on_feature_chains_changed(
         return
 
     if action in ("post_add", "post_remove"):
-        service_keys = list(instance.services.values_list("key", flat=True)) or None
+        service_keys = list(instance.services.values_list("key", flat=True))
         webhook_service.notify(pk_set, service_keys)
 
 

--- a/src/chains/signals.py
+++ b/src/chains/signals.py
@@ -78,6 +78,8 @@ def on_feature_changed(sender: Feature, instance: Feature, **kwargs: Any) -> Non
         # Scope changes are handled by the on_feature_scope_change_post_save signal
         return
 
+    # Pass [] (not None) when feature has no services — None means
+    # "broadcast to all registered services" in notify().
     service_keys = list(instance.services.values_list("key", flat=True))
     chain_ids = (
         Chain.objects.values_list("id", flat=True)

--- a/src/chains/tests/test_signals.py
+++ b/src/chains/tests/test_signals.py
@@ -716,6 +716,21 @@ class WalletHookTestCase(TestCase):
             assert f'"chainId": "{chain.id}"' in body
             assert '"service": "CGW"' in body
 
+    @responses.activate
+    def test_on_wallet_delete_with_chain_and_services(self) -> None:
+        ServiceFactory.create(key="CGW")
+        chain = ChainFactory.create()
+        wallet = WalletFactory.create(key="Test Wallet", chains=(chain,))
+        responses.reset()
+        responses.add(responses.POST, "http://127.0.0.1/v1/hooks/events", status=200)
+
+        wallet.delete()
+
+        assert len(responses.calls) == 1
+        body = responses.calls[0].request.body.decode("utf-8")
+        assert f'"chainId": "{chain.id}"' in body
+        assert '"service": "CGW"' in body
+
 
 @override_settings(CGW_URL="http://127.0.0.1", CGW_AUTH_TOKEN="example-token")
 class GasPriceHookTestCase(TestCase):
@@ -804,6 +819,24 @@ class GasPriceHookTestCase(TestCase):
         responses.add(responses.POST, "http://127.0.0.1/v1/hooks/events", status=200)
 
         GasPriceFactory.create(chain=self.chain)
+
+        assert len(responses.calls) == 2
+        bodies = {call.request.body.decode("utf-8") for call in responses.calls}
+        assert any('"service": "CGW"' in b for b in bodies)
+        assert any('"service": "WALLET_WEB"' in b for b in bodies)
+        for call in responses.calls:
+            body = call.request.body.decode("utf-8")
+            assert f'"chainId": "{self.chain.id}"' in body
+
+    @responses.activate
+    def test_on_gas_price_delete_with_services(self) -> None:
+        ServiceFactory.create(key="CGW")
+        ServiceFactory.create(key="WALLET_WEB")
+        gas_price = GasPriceFactory.create(chain=self.chain)
+        responses.reset()
+        responses.add(responses.POST, "http://127.0.0.1/v1/hooks/events", status=200)
+
+        gas_price.delete()
 
         assert len(responses.calls) == 2
         bodies = {call.request.body.decode("utf-8") for call in responses.calls}

--- a/src/chains/tests/test_signals.py
+++ b/src/chains/tests/test_signals.py
@@ -122,6 +122,26 @@ class ChainNetworkHookTestCase(TestCase):
         )
 
     @responses.activate
+    def test_on_chain_create_no_services_fallback(self) -> None:
+        chain_id = fake.pyint()
+        responses.add(
+            responses.POST,
+            "http://127.0.0.1/v1/hooks/events",
+            status=200,
+            match=[
+                responses.matchers.json_params_matcher(
+                    {"type": "CHAIN_UPDATE", "chainId": str(chain_id)}
+                ),
+            ],
+        )
+
+        ChainFactory.create(id=chain_id)
+
+        assert len(responses.calls) == 1
+        body = responses.calls[0].request.body.decode("utf-8")
+        assert "service" not in body
+
+    @responses.activate
     def test_on_chain_create_with_services(self) -> None:
         ServiceFactory.create(key="CGW")
         ServiceFactory.create(key="WALLET_WEB")

--- a/src/chains/tests/test_signals.py
+++ b/src/chains/tests/test_signals.py
@@ -121,6 +121,42 @@ class ChainNetworkHookTestCase(TestCase):
             == "Basic example-token"
         )
 
+    @responses.activate
+    def test_on_chain_create_with_services(self) -> None:
+        ServiceFactory.create(key="CGW")
+        ServiceFactory.create(key="WALLET_WEB")
+        chain_id = fake.pyint()
+        responses.add(responses.POST, "http://127.0.0.1/v1/hooks/events", status=200)
+
+        ChainFactory.create(id=chain_id)
+
+        assert len(responses.calls) == 2
+        bodies = {call.request.body.decode("utf-8") for call in responses.calls}
+        assert any('"service": "CGW"' in b for b in bodies)
+        assert any('"service": "WALLET_WEB"' in b for b in bodies)
+        for call in responses.calls:
+            body = call.request.body.decode("utf-8")
+            assert f'"chainId": "{chain_id}"' in body
+
+    @responses.activate
+    def test_on_chain_update_with_services(self) -> None:
+        ServiceFactory.create(key="CGW")
+        ServiceFactory.create(key="WALLET_WEB")
+        chain = ChainFactory.create()
+        responses.reset()
+        responses.add(responses.POST, "http://127.0.0.1/v1/hooks/events", status=200)
+
+        chain.currency_name = "Ether"
+        chain.save()
+
+        assert len(responses.calls) == 2
+        bodies = {call.request.body.decode("utf-8") for call in responses.calls}
+        assert any('"service": "CGW"' in b for b in bodies)
+        assert any('"service": "WALLET_WEB"' in b for b in bodies)
+        for call in responses.calls:
+            body = call.request.body.decode("utf-8")
+            assert f'"chainId": "{chain.id}"' in body
+
 
 @override_settings(CGW_URL="http://127.0.0.1", CGW_AUTH_TOKEN="example-token")
 class FeatureHookTestCase(TestCase):
@@ -644,6 +680,22 @@ class WalletHookTestCase(TestCase):
             == "Basic example-token"
         )
 
+    @responses.activate
+    def test_on_wallet_create_with_chain_and_services(self) -> None:
+        ServiceFactory.create(key="CGW")
+        chain = ChainFactory.create()
+        responses.reset()
+        responses.add(responses.POST, "http://127.0.0.1/v1/hooks/events", status=200)
+
+        WalletFactory.create(key="Test Wallet", chains=(chain,))
+
+        # Wallet save (1 chain x 1 service) + M2M add (1 chain x 1 service) = 2 hooks
+        assert len(responses.calls) == 2
+        for call in responses.calls:
+            body = call.request.body.decode("utf-8")
+            assert f'"chainId": "{chain.id}"' in body
+            assert '"service": "CGW"' in body
+
 
 @override_settings(CGW_URL="http://127.0.0.1", CGW_AUTH_TOKEN="example-token")
 class GasPriceHookTestCase(TestCase):
@@ -724,3 +776,19 @@ class GasPriceHookTestCase(TestCase):
             responses.calls[1].request.headers.get("Authorization")
             == "Basic example-token"
         )
+
+    @responses.activate
+    def test_on_gas_price_create_with_services(self) -> None:
+        ServiceFactory.create(key="CGW")
+        ServiceFactory.create(key="WALLET_WEB")
+        responses.add(responses.POST, "http://127.0.0.1/v1/hooks/events", status=200)
+
+        GasPriceFactory.create(chain=self.chain)
+
+        assert len(responses.calls) == 2
+        bodies = {call.request.body.decode("utf-8") for call in responses.calls}
+        assert any('"service": "CGW"' in b for b in bodies)
+        assert any('"service": "WALLET_WEB"' in b for b in bodies)
+        for call in responses.calls:
+            body = call.request.body.decode("utf-8")
+            assert f'"chainId": "{self.chain.id}"' in body


### PR DESCRIPTION
## What it solves

When Chain, GasPrice, or Wallet models are updated, the CHAIN_UPDATE webhook fires with `service=None`, making it impossible for downstream consumers to perform service-aware cache invalidation. Only Feature-related signals included service keys.

## How this PR fixes it

`ChainUpdateWebhookService.notify()` now queries all registered `Service` records when called without explicit `service_keys`, firing one hook per (chain, service) pair. If no services exist in the DB, it falls back to the current behavior (`service=None`).

A subtle but important fix: Feature signal callers previously coerced empty service lists to `None` via `or None`. Under the new semantics `None` means "broadcast to all services", so this would have caused Features with zero associated services to accidentally notify every service. The `or None` coercion is removed — these callers now pass `[]` to mean "no services".

## How to test it

1. Create two `Service` records (e.g., `CGW`, `WALLET_WEB`)
2. Update a `Chain` model field and observe that two webhook calls are made — one per service key
3. Update a `GasPrice` or `Wallet` and verify the same per-service behavior
4. Delete all `Service` records and update a chain — verify a single webhook fires with no `service` field (fallback)