### PR TITLE
Disable gunicorn control server socket

### DIFF
--- a/src/config/gunicorn.py
+++ b/src/config/gunicorn.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
 import multiprocessing
 import os
 from distutils.util import strtobool

--- a/src/config/gunicorn.py
+++ b/src/config/gunicorn.py
@@ -9,3 +9,6 @@ workers = int(os.getenv("WEB_CONCURRENCY", multiprocessing.cpu_count() * 2))
 threads = int(os.getenv("PYTHON_MAX_THREADS", 1))
 
 reload = bool(strtobool(os.getenv("WEB_RELOAD", "false")))
+
+# Disable control socket — incompatible with read-only filesystem
+control_socket = None

--- a/src/config/gunicorn.py
+++ b/src/config/gunicorn.py
@@ -18,3 +18,6 @@ workers = int(os.getenv("WEB_CONCURRENCY", multiprocessing.cpu_count() * 2))
 threads = int(os.getenv("PYTHON_MAX_THREADS", 1))
 
 reload = _parse_bool(os.getenv("WEB_RELOAD", "false"))
+
+# Disable control socket because pods run with read-only root filesystems.
+control_socket = None


### PR DESCRIPTION
## Summary
- Gunicorn 25.1.0 (bumped in #1490) added a control server that creates a Unix socket on disk
- Pods run with read-only root filesystems, causing `[ERROR] Control server error: [Errno 30] Read-only file system` on startup
- This triggers the [config service error monitor](https://app.datadoghq.eu/monitors/8256881)
- Fix: set `control_socket = None` in gunicorn config

## Test plan
- [ ] Verify pod starts without the `Read-only file system` error in devstaging

🤖 Generated with [Claude Code](https://claude.com/claude-code)