### PR TITLE
fix: Revert python version back to a stable one

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.15.0a8-slim
+FROM python:3.14.3-slim
 
 # python
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
## Summary
Revert the dependabot change to python version and use the old stable one, so the build doesnt break (due to missing deps)