### PR TITLE
fix: align django-stubs-ext with django-stubs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ boto3==1.42.91
 Django==6.0.4
 django-cors-headers==4.9.0
 django-storages==1.14.6
-django-stubs-ext==5.2.9
+django-stubs-ext==6.0.3
 djangorestframework==3.17.1
 djangorestframework-camel-case==1.4.2
 drf-yasg[validation]==1.21.15


### PR DESCRIPTION
## Summary
- align django-stubs-ext with django-stubs 6.0.3
- fix the dependency resolution failure in PR #1534

## Verification
- created a fresh Python 3.14 virtualenv
- ran pip install -r requirements-dev.txt successfully