### PR TITLE
Add enum relayerType

### DIFF
--- a/src/chains/migrations/0055_chain_relayer_type.py
+++ b/src/chains/migrations/0055_chain_relayer_type.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
             field=models.CharField(
                 blank=True,
                 choices=[
-                    ("GTF", "Gtf"),
+                    ("GTF", "GTF"),
                     ("RELAY_FEE", "Relay Fee"),
                     ("DAILY_LIMIT", "Daily Limit"),
                     ("NO_FEE_CAMPAIGN", "No Fee Campaign"),

--- a/src/chains/migrations/0055_chain_relayer_type.py
+++ b/src/chains/migrations/0055_chain_relayer_type.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("chains", "0054_chain_vpc_rpc_uri"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="chain",
+            name="relayer_type",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("GTF", "Gtf"),
+                    ("RELAY_FEE", "Relay Fee"),
+                    ("DAILY_LIMIT", "Daily Limit"),
+                    ("NO_FEE_CAMPAIGN", "No Fee Campaign"),
+                ],
+                default=None,
+                help_text="Relayer strategy used by the Safe Client Gateway for this chain. Leave empty for no relayer.",
+                max_length=32,
+                null=True,
+            ),
+        ),
+    ]

--- a/src/chains/models.py
+++ b/src/chains/models.py
@@ -68,6 +68,12 @@ class Chain(models.Model):
         API_KEY_PATH = "API_KEY_PATH"
         NO_AUTHENTICATION = "NO_AUTHENTICATION"
 
+    class RelayerType(models.TextChoices):
+        GTF = "GTF"
+        RELAY_FEE = "RELAY_FEE"
+        DAILY_LIMIT = "DAILY_LIMIT"
+        NO_FEE_CAMPAIGN = "NO_FEE_CAMPAIGN"
+
     id = models.PositiveBigIntegerField(verbose_name="Chain Id", primary_key=True)
     relevance = models.SmallIntegerField(
         default=100
@@ -181,6 +187,14 @@ class Chain(models.Model):
     simulate_tx_accessor_address = EthereumAddressBinaryField(null=True, blank=True)
     safe_web_authn_signer_factory_address = EthereumAddressBinaryField(
         null=True, blank=True
+    )
+    relayer_type = models.CharField(
+        max_length=32,
+        choices=RelayerType.choices,
+        null=True,
+        blank=True,
+        default=None,
+        help_text="Relayer strategy used by the Safe Client Gateway for this chain. Leave empty for no relayer.",
     )
 
     def get_disabled_wallets(self) -> QuerySet["Wallet"]:

--- a/src/chains/models.py
+++ b/src/chains/models.py
@@ -70,9 +70,9 @@ class Chain(models.Model):
 
     class RelayerType(models.TextChoices):
         GTF = "GTF", "GTF"
-        RELAY_FEE = "RELAY_FEE"
-        DAILY_LIMIT = "DAILY_LIMIT"
-        NO_FEE_CAMPAIGN = "NO_FEE_CAMPAIGN"
+        RELAY_FEE = "RELAY_FEE", "Relay Fee"
+        DAILY_LIMIT = "DAILY_LIMIT", "Daily Limit"
+        NO_FEE_CAMPAIGN = "NO_FEE_CAMPAIGN", "No Fee Campaign"
 
     id = models.PositiveBigIntegerField(verbose_name="Chain Id", primary_key=True)
     relevance = models.SmallIntegerField(

--- a/src/chains/models.py
+++ b/src/chains/models.py
@@ -69,7 +69,7 @@ class Chain(models.Model):
         NO_AUTHENTICATION = "NO_AUTHENTICATION"
 
     class RelayerType(models.TextChoices):
-        GTF = "GTF"
+        GTF = "GTF", "GTF"
         RELAY_FEE = "RELAY_FEE"
         DAILY_LIMIT = "DAILY_LIMIT"
         NO_FEE_CAMPAIGN = "NO_FEE_CAMPAIGN"

--- a/src/chains/serializers.py
+++ b/src/chains/serializers.py
@@ -227,6 +227,7 @@ class ChainSerializer(serializers.ModelSerializer[Chain]):
             "recommended_master_copy_version",
             "disabled_wallets",
             "features",
+            "relayer_type",
         ]
 
     @swagger_serializer_method(serializer_or_field=CurrencySerializer)  # type: ignore[untyped-decorator]

--- a/src/chains/tests/factories.py
+++ b/src/chains/tests/factories.py
@@ -78,7 +78,7 @@ class ChainFactory(DjangoModelFactory):  # type: ignore[misc]
     safe_web_authn_signer_factory_address = factory.LazyAttribute(
         lambda o: web3.Account.create().address
     )
-    relayer_type = factory.lazy_attribute(
+    relayer_type = factory.LazyAttribute
         lambda o: random.choice([None, *list(Chain.RelayerType)])
     )
 

--- a/src/chains/tests/factories.py
+++ b/src/chains/tests/factories.py
@@ -78,6 +78,9 @@ class ChainFactory(DjangoModelFactory):  # type: ignore[misc]
     safe_web_authn_signer_factory_address = factory.LazyAttribute(
         lambda o: web3.Account.create().address
     )
+    relayer_type = factory.lazy_attribute(
+        lambda o: random.choice([None, *list(Chain.RelayerType)])
+    )
 
 
 class GasPriceFactory(DjangoModelFactory):  # type: ignore[misc]

--- a/src/chains/tests/factories.py
+++ b/src/chains/tests/factories.py
@@ -78,7 +78,7 @@ class ChainFactory(DjangoModelFactory):  # type: ignore[misc]
     safe_web_authn_signer_factory_address = factory.LazyAttribute(
         lambda o: web3.Account.create().address
     )
-    relayer_type = factory.LazyAttribute
+    relayer_type = factory.LazyAttribute(
         lambda o: random.choice([None, *list(Chain.RelayerType)])
     )
 

--- a/src/chains/tests/test_views.py
+++ b/src/chains/tests/test_views.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from faker import Faker
 from rest_framework.test import APITestCase
 
-from ..models import Feature
+from ..models import Chain, Feature
 from .factories import (
     ChainFactory,
     FeatureFactory,
@@ -355,6 +355,28 @@ class ChainsEnsRegistryTests(APITestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["ensRegistryAddress"], None)
+
+
+class ChainRelayerTypeTests(APITestCase):
+    def test_null_relayer_type(self) -> None:
+        ChainFactory.create(id=1, relayer_type=None)
+        url = reverse("v1:chains:detail", args=[1])
+
+        response = self.client.get(path=url, data=None, format="json")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.json()["relayerType"])
+
+    def test_each_relayer_type_value(self) -> None:
+        for index, relayer_type in enumerate(Chain.RelayerType):
+            with self.subTest(relayer_type=relayer_type.value):
+                ChainFactory.create(id=index, relayer_type=relayer_type)
+                url = reverse("v1:chains:detail", args=[index])
+
+                response = self.client.get(path=url, data=None, format="json")
+
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.json()["relayerType"], relayer_type.value)
 
 
 class ChainGasPriceTests(APITestCase):

--- a/src/chains/tests/test_views.py
+++ b/src/chains/tests/test_views.py
@@ -114,6 +114,7 @@ class ChainJsonPayloadFormatViewTests(APITestCase):
                         "simulateTxAccessorAddress": chain.simulate_tx_accessor_address,
                         "safeWebAuthnSignerFactoryAddress": chain.safe_web_authn_signer_factory_address,
                     },
+                    "relayerType": chain.relayer_type,
                 }
             ],
         }
@@ -257,6 +258,7 @@ class ChainDetailViewTests(APITestCase):
                 "simulateTxAccessorAddress": chain.simulate_tx_accessor_address,
                 "safeWebAuthnSignerFactoryAddress": chain.safe_web_authn_signer_factory_address,
             },
+            "relayerType": chain.relayer_type,
         }
 
         response = self.client.get(path=url, data=None, format="json")


### PR DESCRIPTION
Related to: https://linear.app/safe-global/issue/PLA-1267/cgw-refactor-cgw-env-vars-for-relayer-selection-logic

This pull request introduces support for specifying a relayer strategy for chain.

**Model and Database Updates:**

* Added a new `relayer_type` field to the `Chain` model, allowing selection from several relayer strategies (GTF, Relay Fee, Daily Limit, No Fee Campaign) or leaving it empty for no relayer. This includes a new `RelayerType` enum for valid choices. 

**API and Serialization:**

* Updated the `ChainSerializer` to include the new `relayer_type` field, making it available in API responses.

**Testing and Factories:**

* Modified the chain factory to randomly assign a `relayer_type` for testing purposes.
* Updated tests to verify that the `relayer_type` is present in the API payloads.