### PR TITLE
feat: Use composite CLA action from github-reusable-workflows

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -6,6 +6,8 @@ on:
   pull_request_target:
     types: [opened, closed, synchronize]
 
+permissions: {}
+
 jobs:
   CLAssistant:
     runs-on: ubuntu-latest

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -9,31 +9,21 @@ on:
 jobs:
   CLAssistant:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     steps:
+      - name: Checkout reusable workflows
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: safe-global/github-reusable-workflows
+          token: ${{ secrets.REUSABLE_WORKFLOWS_TOKEN }}
+          path: reusable-workflows
       - name: "CLA Assistant"
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        # Beta Release
-        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        uses: ./reusable-workflows/actions/cla
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # the below token should have repo scope and must be manually added by you in the repository's secret
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ACCESS_TOKEN }}
         with:
-          path-to-signatures: "signatures/version1/cla.json"
-          path-to-document: "https://safe.global/cla"
-          # branch should not be protected
-          branch: "main"
-          allowlist: moisses89,luarx,rmeissner,Uxio0,*bot # may need to update this expression if we add new bots
-
-          #below are the optional inputs - If the optional inputs are not given, then default values will be taken
-          # enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
-          remote-organization-name: "safe-global"
-          # enter the remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)
-          remote-repository-name: "cla-signatures"
-          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
-          #signed-commit-message: 'For example: $contributorName has signed the CLA in #$pullRequestNo'
-          #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
-          #custom-pr-sign-comment: 'The signature to be committed in order to sign the CLA'
-          #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'
-          #lock-pullrequest-aftermerge: false - if you don't want this bot to automatically lock the pull request after merging (default - true)
-          #use-dco-flag: true - If you are using DCO instead of CLA
+          personal-access-token: ${{ secrets.CLA_ACCESS_TOKEN }}
+          allowlist: moisses89,luarx,rmeissner,Uxio0,*bot

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -22,6 +22,7 @@ jobs:
           repository: safe-global/github-reusable-workflows
           token: ${{ secrets.REUSABLE_WORKFLOWS_TOKEN }}
           path: reusable-workflows
+          ref: 4cabe62dbd45f2dd2962eebd09024923207ece0f
       - name: "CLA Assistant"
         uses: ./reusable-workflows/actions/cla
         env:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -26,4 +26,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           personal-access-token: ${{ secrets.CLA_ACCESS_TOKEN }}
-          allowlist: moisses89,luarx,rmeissner,Uxio0,*bot
+          allowlist: moisses89,luarx,rmeissner,Uxio0,diegopazosrego,*bot

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -22,11 +22,10 @@ jobs:
           repository: safe-global/github-reusable-workflows
           token: ${{ secrets.REUSABLE_WORKFLOWS_TOKEN }}
           path: reusable-workflows
-          ref: 4cabe62dbd45f2dd2962eebd09024923207ece0f
+          ref: 42b087a4e41013c8fe57e1aba8abbd5866a7be97
       - name: "CLA Assistant"
         uses: ./reusable-workflows/actions/cla
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           personal-access-token: ${{ secrets.CLA_ACCESS_TOKEN }}
           allowlist: moisses89,luarx,rmeissner,Uxio0,diegopazosrego,*bot

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -28,4 +28,4 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           personal-access-token: ${{ secrets.CLA_ACCESS_TOKEN }}
-          allowlist: moisses89,luarx,rmeissner,Uxio0,diegopazosrego,*bot
+          allowlist: moisses89,luarx,rmeissner,Uxio0,*bot


### PR DESCRIPTION
Migrates the CLA Assistant workflow to use the composite action from `github-reusable-workflows ` instead of defining the steps inline. The calling workflow checks out the private repo using REUSABLE_WORKFLOWS_TOKEN and references the action by local path