### PR TITLE
feat: Use reusable Claude code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,44 +9,15 @@ on:
   pull_request_review_comment:
     types: [created]
 
+permissions: {}
+
 jobs:
   claude-review:
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (contains(github.event.comment.body, '@claude review') &&
-       contains(fromJSON('["MEMBER", "OWNER", "COLLABORATOR"]'), github.event.comment.author_association))
-
-    runs-on: ubuntu-latest
+    uses: safe-global/github-reusable-workflows/.github/workflows/claude-code-review.yaml@c4f0ada72a93640dfd2f720ff47fa462197f47ca # v2.4.15
     permissions:
       contents: read
       pull-requests: read
       issues: read
       id-token: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 1
-
-      - name: Run Claude Code Review
-        id: claude-review
-        uses: anthropics/claude-code-action@476e359e6203e73dad705c8b322e333fabbd7416 # v1.0.119
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-
-          model: "claude-opus-4-6"
-          direct_prompt: |
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
-
-            Be constructive and helpful in your feedback.
-            Make it short and concise, avoid unnecessary details.
-            Only focus on things to improve.
-            Do not need to check the comments of the PR.
-
-          trigger_phrase: "@claude review"
+    secrets:
+      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary

  - Migrates the Claude code review workflow to use the reusable workflow from `safe-global/github-reusable-workflows`
  - Removes duplicated job logic (permissions, steps, model config) from this repo
  - The reusable workflow is pinned to a specific commit SHA for security

  ## Changes

  - `.github/workflows/claude-code-review.yml` now delegates to
  `safe-global/github-reusable-workflows/.github/workflows/claude-code-review.yaml@c4f0ada` (v2.4.15)
  - Trigger events (`workflow_dispatch`, `issue_comment`, `pull_request_review_comment`) remain in this repo
  - Behavior is identical to the previous setup