### PR TITLE
feat: Use composite Claude code review action

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,11 +13,21 @@ permissions: {}
 
 jobs:
   claude-review:
-    uses: safe-global/github-reusable-workflows/.github/workflows/claude-code-review.yaml@c4f0ada72a93640dfd2f720ff47fa462197f47ca # v2.4.15
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
       issues: read
       id-token: write
-    secrets:
-      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+    steps:
+      - name: Checkout reusable workflows
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: safe-global/github-reusable-workflows
+          token: ${{ secrets.REUSABLE_WORKFLOWS_TOKEN }}
+          path: reusable-workflows
+          ref: ed82e15a5851741a1cd23aefbf5b6dcb5ee21432 # v2.4.16
+      - name: Claude Code Review
+        uses: ./reusable-workflows/actions/claude-code-review
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary

  - Migrates the Claude code review workflow to use a composite action from
  `safe-global/github-reusable-workflows`
  - Replaces the broken reusable workflow approach (public repos cannot call private reusable workflows)
  - Uses the same pattern as the CLA action: explicit checkout with `REUSABLE_WORKFLOWS_TOKEN` + composite action
  call
  - Pinned to `ed82e15` (v2.4.16)

  ## Changes

  - `.github/workflows/claude-code-review.yml` now checks out `github-reusable-workflows` and calls
  `actions/claude-code-review`
  - Trigger events and permissions remain in this repo
  - Behavior is identical to the previous setup