### PR TITLE
fix: add least-privilege permissions to CI workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -22,7 +22,7 @@ jobs:
           repository: safe-global/github-reusable-workflows
           token: ${{ secrets.REUSABLE_WORKFLOWS_TOKEN }}
           path: reusable-workflows
-          ref: ed82e15a5851741a1cd23aefbf5b6dcb5ee21432 # v2.4.16
+          ref: f72a861e898dd2d539a0598a1fb43a8ea801ebd1 # main 2026-05-27 (signatures branch)
       - name: "CLA Assistant"
         uses: ./reusable-workflows/actions/cla
         with:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -22,7 +22,7 @@ jobs:
           repository: safe-global/github-reusable-workflows
           token: ${{ secrets.REUSABLE_WORKFLOWS_TOKEN }}
           path: reusable-workflows
-          ref: 42b087a4e41013c8fe57e1aba8abbd5866a7be97
+          ref: ed82e15a5851741a1cd23aefbf5b6dcb5ee21432 # v2.4.16
       - name: "CLA Assistant"
         uses: ./reusable-workflows/actions/cla
         with:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -22,7 +22,7 @@ jobs:
           repository: safe-global/github-reusable-workflows
           token: ${{ secrets.REUSABLE_WORKFLOWS_TOKEN }}
           path: reusable-workflows
-          ref: f72a861e898dd2d539a0598a1fb43a8ea801ebd1 # main 2026-05-27 (signatures branch)
+          ref: c4fd58f9c721aca09b841c8035ce1d115ed5f3c3 # v2.4.18
       - name: "CLA Assistant"
         uses: ./reusable-workflows/actions/cla
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,9 @@ on:
   release:
     types: [released]
 
+permissions:
+  contents: read
+
 jobs:
   linting:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Resolves the six `actions/missing-workflow-permissions` warnings on `test.yml` by adding a workflow-level `permissions: contents: read` block. That's enough for all six jobs: linting/django-check run tests, docker-publish jobs push to DockerHub via `DOCKER_*` secrets, and autodeploy hits an external webhook. None touch GitHub APIs that need elevated `GITHUB_TOKEN` scopes.
