### PR TITLE
fix(chains): renumber duplicate 0055 migration to 0056

### DIFF
--- a/src/chains/migrations/0056_chain_relayer_type.py
+++ b/src/chains/migrations/0056_chain_relayer_type.py
@@ -5,7 +5,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("chains", "0054_chain_vpc_rpc_uri"),
+        ("chains", "0055_gastoken"),
     ]
 
     operations = [


### PR DESCRIPTION
 ## What
  Resolves a duplicate migration number in the `chains` app. Both `0055_gastoken` (#1557) and `0055_chain_relayer_type` (#1555) declared `0054_chain_vpc_rpc_uri` as their dependency, producing **two leaf nodes** in the migration graph. Renumbers the later-merged `0055_chain_relayer_type` → `0056_chain_relayer_type` and repoints its dependency to `0055_gastoken`, restoring a linear chain:
`0054_chain_vpc_rpc_uri → 0055_gastoken → 0056_chain_relayer_type`
  
## Why
With two leaf nodes, `python src/manage.py migrate` fails with *"Conflicting migrations detected; multiple leaf nodes in the migration graph"*, which also breaks the `migrate` step in CI and blocks any deploy from `main`.
  
  ## Why this direction
- `0055_gastoken` merged first and was briefly the valid sole leaf, so it may already be applied in deployed/dev databases — it keeps its number untouched.
- `0055_chain_relayer_type` only ever existed in the broken two-leaf graph, so it could never have been applied from `main`; renaming it is safe everywhere.
- The two operations are independent (`CreateModel GasToken` vs. `AddField chain.relayer_type`), so reordering them changes no emitted SQL.

## Testing
- [x] `python src/manage.py makemigrations --check --dry-run` → no changes detected
- [x] `python src/manage.py migrate` applies cleanly on a fresh database
- [x] `python src/manage.py showmigrations chains` shows a single linear chain