### PR TITLE
Revert "Disable gunicorn control server socket"

### DIFF
--- a/src/config/gunicorn.py
+++ b/src/config/gunicorn.py
@@ -18,6 +18,3 @@ workers = int(os.getenv("WEB_CONCURRENCY", multiprocessing.cpu_count() * 2))
 threads = int(os.getenv("PYTHON_MAX_THREADS", 1))
 
 reload = _parse_bool(os.getenv("WEB_RELOAD", "false"))
-
-# Disable control socket because pods run with read-only root filesystems.
-control_socket = None


### PR DESCRIPTION
Reverts safe-global/safe-config-service#1521

Service is failing with:
```
[2026-06-04 08:32:03 +0000] [1] [ERROR] Unhandled exception in main loop
Traceback (most recent call last):
  File "/app/.venv/lib/python3.14/site-packages/gunicorn/arbiter.py", line 227, in run
    self._start_control_server()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/app/.venv/lib/python3.14/site-packages/gunicorn/arbiter.py", line 967, in _start_control_server
    socket_path = self._get_control_socket_path()
  File "/app/.venv/lib/python3.14/site-packages/gunicorn/arbiter.py", line 949, in _get_control_socket_path
    if not os.path.isabs(socket_path):
           ~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "<frozen posixpath>", line 63, in isabs
TypeError: expected str, bytes or os.PathLike object, not NoneType
```