### PR TITLE
fix: renumber dupe migration 0058 to 0059

### DIFF
--- a/src/chains/migrations/0059_remove_contract_address_fields.py
+++ b/src/chains/migrations/0059_remove_contract_address_fields.py
@@ -7,7 +7,7 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('chains', '0057_chain_relayer_sponsoring'),
+        ('chains', '0058_gastoken_priority'),
     ]
 
     operations = [


### PR DESCRIPTION
## What

Resolves a conflicting-migrations error in the `chains` app: two leaf nodes both
numbered `0058` (`0058_gastoken_priority` and `0058_remove_contract_address_fields`),
each branched off `0057_chain_relayer_sponsoring` in separate PRs (#1587, #1516)
that landed on `main` independently.

CommandError: Conflicting migrations detected; multiple leaf nodes in the
migration graph: (0058_gastoken_priority, 0058_remove_contract_address_fields in chains).



## How

Renumbered `0058_remove_contract_address_fields` → `0059_remove_contract_address_fields`
and repointed its dependency from `0057_chain_relayer_sponsoring` to
`0058_gastoken_priority`, linearizing the graph:

0057 → 0058_gastoken_priority → 0059_remove_contract_address_fields



This follows the same pattern as `5660bb9` ("renumber duplicate 0055 migration to 0056"),
keeping history linear instead of adding a no-op `--merge` migration.

The two operations are independent (one adds `gastoken.priority`, the other removes
unused `chain.*_address` fields), so ordering them linearly is behaviorally a no-op.

`uv run python src/manage.py makemigrations --check --dry-run` now reports
**No changes detected**.