### PR TITLE
fix: Add pre-checkout step to prevent composite action workspace wipe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,12 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          token: ${{ github.token }}
+
       - name: Checkout reusable workflows
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:


### PR DESCRIPTION
actions/checkout inside the composite action deletes the workspace contents when no .git is present, removing the reusable-workflows/ directory loaded in the prior step. Pre-checking out the repo first ensures the workspace is initialized, so the composite checkout does a git fetch instead of a full wipe.