### PR TITLE
feat: Add pull-request and staging CI/CD workflows

### DIFF
--- a/.github/workflows/_build-image.yml
+++ b/.github/workflows/_build-image.yml
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
+# =============================================================================
+# REUSABLE: Build & push a single, IMMUTABLE multi-arch image to GHCR
+# =============================================================================
+# Replaces the inline docker-publish-staging / docker-publish-release jobs.
+# Always pushes an immutable tag (main-<sha> or vX.Y.Z) — never a moving tag
+# like :staging / :latest, so a GitOps controller can pin and roll back cleanly.
+#
+# Registry = GHCR (ghcr.io), authenticated with the auto-provided GITHUB_TOKEN
+# (no static Docker Hub credentials needed).
+# -----------------------------------------------------------------------------
+name: _build-image
+
+on:
+  workflow_call:
+    inputs:
+      image_name:
+        description: Image path WITHOUT tag, e.g. ghcr.io/safe-global/my-service.
+        type: string
+        required: true
+      image_tag:
+        description: Immutable tag to publish (e.g. main-abc1234 or v4.38.0).
+        type: string
+        required: true
+      push:
+        description: Push to the registry (false = build-only validation, e.g. on PRs).
+        type: boolean
+        default: true
+      platforms:
+        type: string
+        default: linux/amd64,linux/arm64
+      version:
+        description: Passed through as the VERSION build-arg.
+        type: string
+        default: ""
+      also_tag_latest:
+        description: >-
+          Also push a :latest tag alongside the immutable tag. Use for production
+          releases only (matches diagram "vX.Y.Z + latest"). Never set on staging
+          builds — :latest on a main-<sha> tag is meaningless.
+        type: boolean
+        default: false
+    outputs:
+      image:
+        description: Fully-qualified image reference that was built.
+        value: ${{ jobs.build.outputs.image }}
+      digest:
+        description: Image digest (sha256:...).
+        value: ${{ jobs.build.outputs.digest }}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ inputs.image_name }}:${{ inputs.image_tag }}
+      digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - name: Compute image tags
+        id: tags
+        run: |
+          TAGS="${{ inputs.image_name }}:${{ inputs.image_tag }}"
+          if [ "${{ inputs.also_tag_latest }}" = "true" ]; then
+            TAGS="${TAGS}"$'\n'"${{ inputs.image_name }}:latest"
+          fi
+          {
+            echo "tags<<EOF"
+            echo "$TAGS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+      - name: Log in to GHCR
+        if: ${{ inputs.push }}
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build & push
+        id: build
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          platforms: ${{ inputs.platforms }}
+          push: ${{ inputs.push }}
+          tags: ${{ steps.tags.outputs.tags }}
+          build-args: |
+            VERSION=${{ inputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false
+      - name: Summary
+        run: |
+          {
+            echo "### Image"
+            echo "- \`${{ inputs.image_name }}:${{ inputs.image_tag }}\`"
+            if [ "${{ inputs.also_tag_latest }}" = "true" ]; then
+              echo "- \`${{ inputs.image_name }}:latest\`"
+            fi
+            echo "- digest: \`${{ steps.build.outputs.digest }}\`"
+            echo "- pushed: \`${{ inputs.push }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/_ci-python.yml
+++ b/.github/workflows/_ci-python.yml
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
+# =============================================================================
+# REUSABLE: CI quality gate (lint · license headers · mypy · pytest+coverage)
+# =============================================================================
+# Mirrors the jobs in the repo's former test.yml as an `on: workflow_call`
+# building block so the PR gate and the trunk (push-to-main) pipeline share one
+# definition. Pure quality checks — it never builds or pushes images.
+# -----------------------------------------------------------------------------
+name: _ci
+
+on:
+  workflow_call:
+    inputs:
+      python_version:
+        description: Python version to lint/type-check/test against.
+        type: string
+        default: "3.14.3"
+      mypy_paths:
+        description: >-
+          Space-separated list of source paths passed to mypy --strict.
+          Example: "src/chains src/safe_apps" or "src/app".
+        type: string
+        default: "src"
+      ref:
+        description: Git ref to check out. Empty = the ref that triggered the caller.
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  linting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          python-version: ${{ inputs.python_version }}
+          enable-cache: true
+      - run: uv sync --frozen
+      - name: pre-commit (all files, skip license-headers)
+        run: SKIP=license-headers uv run pre-commit run --all-files
+
+  license-headers:
+    # Diff-based hook: only meaningful when we have a base to diff against.
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.ref }}
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          python-version: ${{ inputs.python_version }}
+          enable-cache: true
+      - run: uv sync --frozen
+      - name: Run license-headers on added/modified files
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_REF="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE_REF="${{ github.event.before }}"
+          fi
+
+          if [ -z "$BASE_REF" ] || [ "$BASE_REF" = "0000000000000000000000000000000000000000" ]; then
+            echo "No valid base ref; skipping."
+            exit 0
+          fi
+
+          if ! git cat-file -e "$BASE_REF^{commit}" 2>/dev/null; then
+            echo "$BASE_REF is not available locally; falling back to HEAD^."
+            BASE_REF="HEAD^"
+          fi
+
+          CHANGED_FILES=$(git diff --name-only --diff-filter=AM "$BASE_REF" HEAD)
+
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No added or modified files; skipping."
+            exit 0
+          fi
+
+          # word-splitting is intentional: pass each changed file as a separate arg
+          # shellcheck disable=SC2086
+          uv run pre-commit run license-headers --files $CHANGED_FILES
+
+  django-check:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      SECRET_KEY: insecure-ci-only-key
+      POSTGRES_HOST: localhost
+      POSTGRES_PORT: "5432"
+      # Placeholders so Django settings that read these don't blow up in CI.
+      AWS_ACCESS_KEY_ID: example
+      AWS_SECRET_ACCESS_KEY: example
+      AWS_STORAGE_BUCKET_NAME: example
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          python-version: ${{ inputs.python_version }}
+          enable-cache: true
+      - run: uv sync --frozen
+      - name: mypy (strict)
+        run: uv run mypy --strict ${{ inputs.mypy_paths }}
+      - name: Check for missing migrations
+        run: uv run python src/manage.py makemigrations --check --dry-run
+      - name: Apply migrations
+        run: uv run python src/manage.py migrate
+      - name: Django system check
+        run: uv run python src/manage.py check
+      - name: Tests + coverage
+        run: |
+          uv run coverage run -m pytest src
+          uv run coverage lcov -o coverage.lcov
+      - name: Upload coverage to Coveralls
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
+        with:
+          file: coverage.lcov

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -1,0 +1,211 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
+# =============================================================================
+# REUSABLE: GitOps deploy — bump the Helm image tag in the infra repo
+# =============================================================================
+# The deploy IS a git commit. This job mints a GitHub App token scoped to the
+# separate Terraform/Helm repo, checks it out, rewrites `image.tag` in the
+# environment's values file, and pushes. ArgoCD (watching that repo) reconciles
+# the new tag onto the cluster automatically — CI never touches kubectl/helm.
+#
+# Optional production gate: wait for ArgoCD health + smoke-test the service;
+# on failure, `git revert` the bump (ArgoCD rolls back to the previous tag).
+# -----------------------------------------------------------------------------
+name: _deploy
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: Target environment (staging | production). Also selects env-scoped secrets.
+        type: string
+        required: true
+      image_tag:
+        description: Immutable image tag to deploy (must already be pushed to the registry).
+        type: string
+        required: true
+      infra_repo:
+        description: owner/name of the Terraform/Helm/values repo (e.g. safe-global/my-service-infra).
+        type: string
+        required: true
+      values_file:
+        description: Path (within infra_repo) to the env values file to bump.
+        type: string
+        required: true
+      image_tag_path:
+        description: yq path to the image tag field inside values_file.
+        type: string
+        default: .image.tag
+      argocd_app:
+        description: ArgoCD Application name to wait on (optional; production gate).
+        type: string
+        default: ""
+      health_url:
+        description: URL to smoke-test after deploy (optional; production gate).
+        type: string
+        default: ""
+      health_gate:
+        description: >-
+          Enable the full production gate: ArgoCD wait + smoke test + auto-rollback
+          on failure. Set true for production only. For staging, set health_url
+          without health_gate to get a non-rolling smoke test (no rollback).
+        type: boolean
+        default: false
+      post_deploy_checks:
+        description: >-
+          Optional bash commands run after the smoke test. Any non-zero exit
+          triggers rollback (same as the smoke test). Useful for service-specific
+          checks such as API endpoint assertions or DB migration verification.
+          Only executed when health_gate is true.
+          Example: |
+            curl -fsS https://example.com/api/v1/chains/ | jq -e '.count > 0'
+            curl -fsS https://example.com/api/v1/safe-apps/ | jq -e '.count > 0'
+        type: string
+        default: ""
+    secrets:
+      app_id:
+        required: true
+      app_private_key:
+        required: true
+      gpg_private_key:
+        description: GPG private key for signing the deploy commit (enterprise signed-commits rule).
+        required: true
+      gpg_passphrase:
+        description: Passphrase for the GPG private key.
+        required: true
+      argocd_server:
+        required: false
+      argocd_token:
+        required: false
+
+# Serialise deploys per-environment so two pushes can't race the infra repo.
+concurrency:
+  group: deploy-${{ inputs.environment }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    steps:
+      - name: Resolve infra repo name
+        id: infra
+        env:
+          INFRA: ${{ inputs.infra_repo }}
+        run: echo "name=${INFRA##*/}" >> "$GITHUB_OUTPUT"
+
+      - name: Mint GitHub App token (scoped to infra repo)
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ secrets.app_id }}
+          private-key: ${{ secrets.app_private_key }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ steps.infra.outputs.name }}
+          permission-contents: write
+
+      - name: Checkout infra repo
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: ${{ inputs.infra_repo }}
+          token: ${{ steps.app-token.outputs.token }}
+          path: infra
+          fetch-depth: 1
+          persist-credentials: true
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
+        with:
+          gpg_private_key: ${{ secrets.gpg_private_key }}
+          passphrase: ${{ secrets.gpg_passphrase }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_config_global: true
+          git_committer_name: 'GH Signer Bot'
+          git_committer_email: 'gh-signer-bot@safe.global'
+
+      - name: Bump image tag (yq) & push
+        id: commit
+        working-directory: infra
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag }}
+          VALUES_FILE: ${{ inputs.values_file }}
+          TAG_PATH: ${{ inputs.image_tag_path }}
+          ENVIRONMENT: ${{ inputs.environment }}
+        run: |
+          set -euo pipefail
+          # mikefarah yq v4 is preinstalled on ubuntu-latest runners.
+          yq -i "${TAG_PATH} = strenv(IMAGE_TAG)" "$VALUES_FILE"
+          git add "$VALUES_FILE"
+          if git diff --cached --quiet; then
+            echo "Image tag already ${IMAGE_TAG} — nothing to deploy."
+            exit 0
+          fi
+          git commit -m "deploy(${ENVIRONMENT}): ${GITHUB_REPOSITORY##*/} ${IMAGE_TAG}"
+          for attempt in 1 2 3; do
+            if git push; then
+              echo "pushed=true" >> "$GITHUB_OUTPUT"
+              echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+              echo "Deployed ${IMAGE_TAG} to ${ENVIRONMENT}."
+              exit 0
+            fi
+            echo "push rejected (attempt ${attempt}) — rebasing on infra HEAD"
+            git pull --rebase
+          done
+          echo "::error::Failed to push deploy commit after 3 attempts."
+          exit 1
+
+      - name: Wait for ArgoCD sync & health
+        if: ${{ inputs.health_gate && inputs.argocd_app != '' }}
+        env:
+          ARGOCD_SERVER: ${{ secrets.argocd_server }}
+          ARGOCD_AUTH_TOKEN: ${{ secrets.argocd_token }}
+        run: |
+          set -euo pipefail
+          if [ -z "${ARGOCD_SERVER:-}" ] || [ -z "${ARGOCD_AUTH_TOKEN:-}" ]; then
+            echo "ArgoCD credentials not provided — skipping explicit wait, relying on smoke test."
+            exit 0
+          fi
+          # Pin the CLI version (don't pull a moving "latest" at runtime).
+          ARGOCD_VERSION="v2.13.3"
+          curl -sSL -o /tmp/argocd \
+            "https://github.com/argoproj/argo-cd/releases/download/${ARGOCD_VERSION}/argocd-linux-amd64"
+          chmod +x /tmp/argocd
+          /tmp/argocd app wait "${{ inputs.argocd_app }}" \
+            --health --sync --timeout 300 --grpc-web
+
+      - name: Smoke test
+        if: ${{ inputs.health_url != '' }}
+        run: |
+          set -euo pipefail
+          curl -fsS --retry 6 --retry-delay 10 --retry-all-errors "${{ inputs.health_url }}"
+
+      - name: Custom post-deploy checks
+        if: ${{ inputs.health_gate && inputs.post_deploy_checks != '' }}
+        run: |
+          set -euo pipefail
+          ${{ inputs.post_deploy_checks }}
+
+      - name: Roll back on failed health gate
+        if: ${{ failure() && steps.commit.outputs.pushed == 'true' && inputs.health_gate }}
+        working-directory: infra
+        env:
+          DEPLOY_SHA: ${{ steps.commit.outputs.sha }}
+        run: |
+          set -euo pipefail
+          echo "::warning::Health gate failed — reverting ${DEPLOY_SHA}; ArgoCD will roll back."
+          # Revert by explicit SHA (not HEAD) and retry the push: the infra repo may
+          # have advanced during the multi-minute health gate, making a bare push a
+          # non-fast-forward. Without this, the rollback would silently fail.
+          git pull --rebase
+          git revert --no-edit "$DEPLOY_SHA"
+          for attempt in 1 2 3; do
+            # On success still exit non-zero so the bad release is surfaced as a failure.
+            if git push; then exit 1; fi
+            echo "rollback push rejected (attempt ${attempt}) — rebasing"
+            git pull --rebase
+          done
+          echo "::error::Rollback push failed after 3 attempts — manual intervention required."
+          exit 1

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
+# =============================================================================
+# REUSABLE: Automated release via release-please (replaces manual release.yml)
+# =============================================================================
+# Runs on every push to main. release-please maintains ONE rolling "Release PR"
+# whose version + CHANGELOG are derived from Conventional Commits. Merging that
+# PR tags the commit and publishes a GitHub Release.
+#
+# CRITICAL — the release is created with a GitHub App token, NOT GITHUB_TOKEN:
+# a release created by GITHUB_TOKEN does NOT emit a `release: published` event
+# (GitHub loop-prevention), so production.yml would never fire. The App token
+# makes the event propagate → fully event-driven prod deploy, zero manual steps.
+# -----------------------------------------------------------------------------
+name: _release
+
+on:
+  workflow_call:
+    inputs:
+      release_type:
+        description: release-please release type (python for this repo).
+        type: string
+        default: python
+      auto_merge_release:
+        description: >-
+          Auto-merge the Release PR so cutting a release (and the prod deploy it
+          triggers) needs no second human action. Requires the CI GitHub App to
+          be a review-bypass actor on main for its own PRs (see CICD-IMPLEMENTATION.md).
+          Set false to make merging the Release PR the deliberate release gate.
+        type: boolean
+        default: true
+    secrets:
+      app_id:
+        description: GitHub App ID (App installed on this repo, contents+PRs write).
+        required: true
+      app_private_key:
+        description: GitHub App private key (PEM).
+        required: true
+    outputs:
+      release_created:
+        description: "'true' when a release was just published (string!)."
+        value: ${{ jobs.release-please.outputs.release_created }}
+      tag_name:
+        value: ${{ jobs.release-please.outputs.tag_name }}
+      version:
+        value: ${{ jobs.release-please.outputs.version }}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+      version: ${{ steps.release.outputs.version }}
+    steps:
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ secrets.app_id }}
+          private-key: ${{ secrets.app_private_key }}
+      - name: Run release-please
+        id: release
+        uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f # v4.1.3
+        with:
+          release-type: ${{ inputs.release_type }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      # When a Release PR is (re)opened, turn on auto-merge so it merges itself
+      # once CI is green — no human needed. The merge publishes the Release,
+      # which fires production.yml. Feature PRs still require their human review.
+      - name: Enable auto-merge on the Release PR
+        if: ${{ inputs.auto_merge_release && steps.release.outputs.prs_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_JSON: ${{ steps.release.outputs.pr }}
+        run: |
+          set -euo pipefail
+          PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
+          gh pr merge --auto --squash "$PR_NUMBER" --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,6 +20,6 @@ permissions:
 
 jobs:
   ci:
-    uses: safe-global/github-reusable-workflows/.github/workflows/_ci-python.yml@563dd4298f3f6e470910617369e06eac955dcf22 # v2.4.23
+    uses: ./.github/workflows/_ci-python.yml
     with:
       mypy_paths: "src/chains src/safe_apps"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
+# =============================================================================
+# CALLER: Pull request gate
+# =============================================================================
+# Event: any PR opened/updated against any branch.
+# The ONLY human-gated step in the whole pipeline is the review this enables.
+# Make the three _ci jobs (linting, license-headers, django-check) REQUIRED
+# status checks in branch protection, plus "Require 1 approving review", plus
+# "Require branches up to date". Everything after merge is automated.
+#
+# (cla.yml and claude-code-review.yml stay as-is — they already run on PR events.)
+# -----------------------------------------------------------------------------
+name: Pull request
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    uses: safe-global/github-reusable-workflows/.github/workflows/_ci-python.yml@563dd4298f3f6e470910617369e06eac955dcf22 # v2.4.23
+    with:
+      mypy_paths: "src/chains src/safe_apps"

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
+# =============================================================================
+# CALLER: Trunk pipeline → STAGING (event: push to main)
+# =============================================================================
+# Every merge to main: re-run CI on the merge result, build an immutable image
+# tagged main-<short-sha>, then GitOps-deploy it to staging. No manual steps.
+# -----------------------------------------------------------------------------
+name: Staging
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: staging
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    uses: safe-global/github-reusable-workflows/.github/workflows/_ci-python.yml@563dd4298f3f6e470910617369e06eac955dcf22 # v2.4.23
+    with:
+      mypy_paths: "src/chains src/safe_apps"
+
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+    steps:
+      - id: tag
+        run: echo "tag=main-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: [ci, prepare]
+    uses: safe-global/github-reusable-workflows/.github/workflows/_build-image.yml@563dd4298f3f6e470910617369e06eac955dcf22 # v2.4.23
+    with:
+      image_name: ghcr.io/safe-global/safe-config-service
+      image_tag: ${{ needs.prepare.outputs.tag }}
+      version: ${{ needs.prepare.outputs.tag }}
+
+  deploy-staging:
+    needs: [prepare, build]
+    uses: safe-global/github-reusable-workflows/.github/workflows/_deploy.yml@563dd4298f3f6e470910617369e06eac955dcf22 # v2.4.23
+    with:
+      environment: staging
+      image_tag: ${{ needs.prepare.outputs.tag }}
+      infra_repo: safe-global/safe-config-service-infra-tf
+      values_file: apps/safe-config-service/values-staging.yaml
+      image_tag_path: .web.imageTag
+      health_url: https://safe-config.staging.5afe.dev/check/
+      health_gate: false
+    secrets:
+      app_id: ${{ secrets.CI_APP_ID }}
+      app_private_key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+      gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: safe-global/github-reusable-workflows/.github/workflows/_ci-python.yml@563dd4298f3f6e470910617369e06eac955dcf22 # v2.4.23
+    uses: ./.github/workflows/_ci-python.yml
     with:
       mypy_paths: "src/chains src/safe_apps"
 
@@ -35,7 +35,7 @@ jobs:
 
   build:
     needs: [ci, prepare]
-    uses: safe-global/github-reusable-workflows/.github/workflows/_build-image.yml@563dd4298f3f6e470910617369e06eac955dcf22 # v2.4.23
+    uses: ./.github/workflows/_build-image.yml
     with:
       image_name: ghcr.io/safe-global/safe-config-service
       image_tag: ${{ needs.prepare.outputs.tag }}
@@ -43,7 +43,7 @@ jobs:
 
   deploy-staging:
     needs: [prepare, build]
-    uses: safe-global/github-reusable-workflows/.github/workflows/_deploy.yml@563dd4298f3f6e470910617369e06eac955dcf22 # v2.4.23
+    uses: ./.github/workflows/_deploy.yml
     with:
       environment: staging
       image_tag: ${{ needs.prepare.outputs.tag }}


### PR DESCRIPTION
feat: Add pull-request and staging CI/CD workflows

- pull-request.yml: runs _ci-python on every PR (linting, license-headers, django-check), gates merge via branch protection required status checks
- staging.yml: on push to main, builds ghcr.io/safe-global/safe-config-service:main-<sha> and GitOps-deploys to staging via safe-config-service-infra-tf

feat: Add reusable workflows locally and wire pull-request + staging CI/CD

- GitHub blocks public repos from calling reusable workflows in private repos (public→private restriction — no bypass available via GitHub App, PAT, or OIDC). The original SHA reference safe-global/github-reusable-workflows/...@563dd429 failed with "workflow was not found"
- Copies _ci-python.yml, _build-image.yml, _deploy.yml, _release.yml from github-reusable-workflows v2.4.23 locally into .github/workflows/
- Updates pull-request.yml and staging.yml callers to use uses: ./.github/workflows/_ci-python.yml (local references)

Safety

test.yml and release.yml remain untouched — production stays on the existing Docker Hub pipeline until PR-3b (CLOUD-931). The _*.yml copies are purely additive.

production.yml and release-please.yml are intentionally excluded from this PR — they go in PR-3b (atomic production cutover).