### PR TITLE
feat(ci): deploy imageTag bump via PR instead of direct push

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -153,7 +153,9 @@ jobs:
             exit 0
           fi
           git commit -m "deploy(${ENVIRONMENT}): ${REPO} ${IMAGE_TAG}"
-          git push origin "$BRANCH"
+          # --force handles re-runs of failed workflows where the branch already exists.
+          # Deploy branches are ephemeral and only written by this workflow.
+          git push --force origin "$BRANCH"
 
           PR_URL=$(gh pr create \
             --base main \
@@ -161,7 +163,10 @@ jobs:
             --title "deploy(${ENVIRONMENT}): ${REPO} ${IMAGE_TAG}" \
             --body "Automated deploy · [CI run #${GITHUB_RUN_ID}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})")
 
-          # --rebase preserves the GPG-signed commit; retry on conflict with infra HEAD.
+          # --rebase keeps the locally-signed commit when the branch is already up-to-date
+          # with main; a server-side rebase (race window) produces a web-flow-signed commit
+          # instead — verify the infra repo accepts web-flow signatures end-to-end.
+          # Retry on conflict: rebase deploy branch on latest infra HEAD and re-attempt.
           for attempt in 1 2 3; do
             if gh pr merge "$PR_URL" --rebase --delete-branch; then
               break
@@ -173,7 +178,17 @@ jobs:
             git push --force-with-lease origin "$BRANCH"
           done
 
-          MERGE_SHA=$(gh pr view "$PR_URL" --json mergeCommit --jq '.mergeCommit.oid')
+          # mergeCommit.oid can lag a few seconds after gh pr merge returns.
+          MERGE_SHA=""
+          for i in 1 2 3 4 5; do
+            MERGE_SHA=$(gh pr view "$PR_URL" --json mergeCommit --jq '.mergeCommit.oid // empty')
+            [ -n "$MERGE_SHA" ] && break
+            sleep 2
+          done
+          if [ -z "$MERGE_SHA" ]; then
+            git fetch origin main
+            MERGE_SHA=$(git rev-parse origin/main)
+          fi
           echo "pushed=true" >> "$GITHUB_OUTPUT"
           echo "sha=${MERGE_SHA}" >> "$GITHUB_OUTPUT"
           echo "Deployed ${IMAGE_TAG} to ${ENVIRONMENT} — ${PR_URL}"

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -174,20 +174,25 @@ jobs:
             [ "$attempt" -eq 3 ] && { echo "::error::PR merge failed after 3 attempts."; exit 1; }
             echo "Merge attempt ${attempt} failed — rebasing deploy branch on infra HEAD"
             git fetch origin
-            git rebase origin/main
+            git rebase origin/main || { git rebase --abort; echo "::error::Rebase conflict — manual resolution required. Open PR: ${PR_URL}"; exit 1; }
             git push --force-with-lease origin "$BRANCH"
           done
 
           # mergeCommit.oid can lag a few seconds after gh pr merge returns.
           MERGE_SHA=""
-          for i in 1 2 3 4 5; do
+          for attempt in 1 2 3 4 5; do
             MERGE_SHA=$(gh pr view "$PR_URL" --json mergeCommit --jq '.mergeCommit.oid // empty')
             [ -n "$MERGE_SHA" ] && break
             sleep 2
           done
           if [ -z "$MERGE_SHA" ]; then
+            # Fallback: find the commit by title — safe under concurrent unrelated deploys.
             git fetch origin main
-            MERGE_SHA=$(git rev-parse origin/main)
+            MERGE_SHA=$(git log origin/main --grep "^deploy(${ENVIRONMENT}): ${REPO} ${IMAGE_TAG}$" -n1 --format=%H)
+          fi
+          if [ -z "$MERGE_SHA" ]; then
+            echo "::error::Could not resolve merge SHA — rollback not possible if health gate fails."
+            exit 1
           fi
           echo "pushed=true" >> "$GITHUB_OUTPUT"
           echo "sha=${MERGE_SHA}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -2,10 +2,12 @@
 # =============================================================================
 # REUSABLE: GitOps deploy — bump the Helm image tag in the infra repo
 # =============================================================================
-# The deploy IS a git commit. This job mints a GitHub App token scoped to the
-# separate Terraform/Helm repo, checks it out, rewrites `image.tag` in the
-# environment's values file, and pushes. ArgoCD (watching that repo) reconciles
-# the new tag onto the cluster automatically — CI never touches kubectl/helm.
+# The deploy is a PR against the infra repo. This job mints a GitHub App token
+# scoped to the separate Terraform/Helm repo, checks it out on a deploy branch,
+# rewrites the image tag in the environment's values file, opens a PR, and
+# squash-merges it immediately. ArgoCD (watching that repo) reconciles the new
+# tag onto the cluster automatically — CI never touches kubectl/helm.
+# Each deploy leaves a merged PR in infra-tf, enabling one-click GitHub reverts.
 #
 # Optional production gate: wait for ArgoCD health + smoke-test the service;
 # on failure, `git revert` the bump (ArgoCD rolls back to the previous tag).
@@ -105,6 +107,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: ${{ steps.infra.outputs.name }}
           permission-contents: write
+          permission-pull-requests: write
 
       - name: Checkout infra repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -126,16 +129,22 @@ jobs:
           git_committer_name: 'GH Signer Bot'
           git_committer_email: 'gh-signer-bot@safe.global'
 
-      - name: Bump image tag (yq) & push
+      - name: Bump image tag (yq), open PR & merge
         id: commit
         working-directory: infra
         env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           IMAGE_TAG: ${{ inputs.image_tag }}
           VALUES_FILE: ${{ inputs.values_file }}
           TAG_PATH: ${{ inputs.image_tag_path }}
           ENVIRONMENT: ${{ inputs.environment }}
+          INFRA_REPO: ${{ inputs.infra_repo }}
         run: |
           set -euo pipefail
+          REPO="${GITHUB_REPOSITORY##*/}"
+          BRANCH="deploy/${ENVIRONMENT}/${REPO}-${IMAGE_TAG}"
+
+          git checkout -b "$BRANCH"
           # mikefarah yq v4 is preinstalled on ubuntu-latest runners.
           yq -i "${TAG_PATH} = strenv(IMAGE_TAG)" "$VALUES_FILE"
           git add "$VALUES_FILE"
@@ -143,19 +152,21 @@ jobs:
             echo "Image tag already ${IMAGE_TAG} — nothing to deploy."
             exit 0
           fi
-          git commit -m "deploy(${ENVIRONMENT}): ${GITHUB_REPOSITORY##*/} ${IMAGE_TAG}"
-          for attempt in 1 2 3; do
-            if git push; then
-              echo "pushed=true" >> "$GITHUB_OUTPUT"
-              echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-              echo "Deployed ${IMAGE_TAG} to ${ENVIRONMENT}."
-              exit 0
-            fi
-            echo "push rejected (attempt ${attempt}) — rebasing on infra HEAD"
-            git pull --rebase
-          done
-          echo "::error::Failed to push deploy commit after 3 attempts."
-          exit 1
+          git commit -m "deploy(${ENVIRONMENT}): ${REPO} ${IMAGE_TAG}"
+          git push origin "$BRANCH"
+
+          PR_URL=$(gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "deploy(${ENVIRONMENT}): ${REPO} ${IMAGE_TAG}" \
+            --body "Automated deploy · [CI run #${GITHUB_RUN_ID}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})")
+
+          gh pr merge "$PR_URL" --squash --delete-branch
+
+          MERGE_SHA=$(gh pr view "$PR_URL" --json mergeCommit --jq '.mergeCommit.oid')
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
+          echo "sha=${MERGE_SHA}" >> "$GITHUB_OUTPUT"
+          echo "Deployed ${IMAGE_TAG} to ${ENVIRONMENT} — ${PR_URL}"
 
       - name: Wait for ArgoCD sync & health
         if: ${{ inputs.health_gate && inputs.argocd_app != '' }}

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -161,7 +161,17 @@ jobs:
             --title "deploy(${ENVIRONMENT}): ${REPO} ${IMAGE_TAG}" \
             --body "Automated deploy · [CI run #${GITHUB_RUN_ID}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})")
 
-          gh pr merge "$PR_URL" --squash --delete-branch
+          # --rebase preserves the GPG-signed commit; retry on conflict with infra HEAD.
+          for attempt in 1 2 3; do
+            if gh pr merge "$PR_URL" --rebase --delete-branch; then
+              break
+            fi
+            [ "$attempt" -eq 3 ] && { echo "::error::PR merge failed after 3 attempts."; exit 1; }
+            echo "Merge attempt ${attempt} failed — rebasing deploy branch on infra HEAD"
+            git fetch origin
+            git rebase origin/main
+            git push --force-with-lease origin "$BRANCH"
+          done
 
           MERGE_SHA=$(gh pr view "$PR_URL" --json mergeCommit --jq '.mergeCommit.oid')
           echo "pushed=true" >> "$GITHUB_OUTPUT"
@@ -207,10 +217,10 @@ jobs:
         run: |
           set -euo pipefail
           echo "::warning::Health gate failed — reverting ${DEPLOY_SHA}; ArgoCD will roll back."
-          # Revert by explicit SHA (not HEAD) and retry the push: the infra repo may
-          # have advanced during the multi-minute health gate, making a bare push a
-          # non-fast-forward. Without this, the rollback would silently fail.
-          git pull --rebase
+          # After gh pr merge --delete-branch the working tree is left on the now-deleted
+          # deploy branch. Explicitly switch to main before reverting.
+          git checkout main
+          git pull --rebase origin main
           git revert --no-edit "$DEPLOY_SHA"
           for attempt in 1 2 3; do
             # On success still exit non-zero so the bad release is surfaced as a failure.


### PR DESCRIPTION
Opens a squash-merged PR on the infra repo per deploy so each environment bump has a GitHub-revertible audit trail.