### PR TITLE
feat(ci): Add workflow_dispatch recovery path to production.yml

### DIFF
--- a/.github/workflows/_build-image.yml
+++ b/.github/workflows/_build-image.yml
@@ -22,6 +22,14 @@ on:
         description: Immutable tag to publish (e.g. main-abc1234 or v4.38.0).
         type: string
         required: true
+      ref:
+        description: >-
+          Git ref (tag/branch/SHA) to check out and build. Empty = the ref that
+          triggered the workflow. Set explicitly when the caller runs from a
+          different ref than the source to build (e.g. a manual redeploy of an
+          existing tag dispatched from the default branch).
+        type: string
+        default: ""
       push:
         description: Push to the registry (false = build-only validation, e.g. on PRs).
         type: boolean
@@ -60,6 +68,8 @@ jobs:
       digest: ${{ steps.build.outputs.digest }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.ref }}
       - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Compute image tags

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -6,12 +6,23 @@
 # Runs CI on the release commit, builds an immutable image tagged with the
 # release version, then GitOps-deploys it to production with a full health gate:
 # ArgoCD wait + smoke test + auto-rollback on failure.
+#
+# workflow_dispatch is a manual recovery path: it runs THIS (fixed) workflow
+# from the default branch while building/deploying the tag you pass as `tag`.
+# Use it when a release's own tagged workflow is broken and the release event
+# can't be re-run cleanly.
 # -----------------------------------------------------------------------------
 name: Production
 
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Git tag / version to build and deploy (e.g. v2.97.0).
+        type: string
+        required: true
 
 permissions:
   contents: read
@@ -35,18 +46,21 @@ jobs:
     steps:
       - id: tag
         env:
-          TAG: ${{ github.event.release.tag_name }}
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
         run: echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
   build:
     needs: [ci, prepare]
-    if: ${{ !github.event.release.prerelease }}
+    # Build on manual dispatch, or on any non-prerelease GitHub Release.
+    if: ${{ github.event_name != 'release' || !github.event.release.prerelease }}
     uses: ./.github/workflows/_build-image.yml
     with:
       image_name: ghcr.io/safe-global/safe-config-service
       image_tag: ${{ needs.prepare.outputs.tag }}
       version: ${{ needs.prepare.outputs.tag }}
-      also_tag_latest: ${{ !github.event.release.prerelease }}
+      also_tag_latest: ${{ github.event_name != 'release' || !github.event.release.prerelease }}
+      # On dispatch, build the exact tagged source (not the default branch HEAD).
+      ref: ${{ github.event.release.tag_name || inputs.tag }}
 
   deploy-production:
     needs: [prepare, build]


### PR DESCRIPTION
`production.yml `gains a workflow_dispatch trigger with a `tag` input so a release can be built and deployed from the default branch (fixed workflows) when its own tagged workflow is broken and the release event can't be re-run.
`_build-image.yml` gains a `ref` input so the dispatch builds the exact tagged source rather than the default-branch HEAD.