### PR TITLE
ci: Harden deploy pipeline - roll-forward + staging gate + version-pol 

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -47,16 +47,27 @@ on:
         default: ""
       health_gate:
         description: >-
-          Enable the full production gate: ArgoCD wait + smoke test + auto-rollback
-          on failure. Set true for production only. For staging, set health_url
-          without health_gate to get a non-rolling smoke test (no rollback).
+          Enable the full production gate: ArgoCD wait + smoke test + post-deploy
+          checks. Set true for production only. For staging, set health_url
+          without health_gate to get a non-rolling smoke test.
         type: boolean
         default: false
+      auto_rollback:
+        description: >-
+          On a failed health gate, git-revert the image bump so ArgoCD rolls back
+          to the previous tag. Only meaningful when health_gate is true. Set FALSE
+          for services with forward-only DB migrations: reverting the image across
+          a migration leaves code and schema mismatched and breaks the service —
+          the safe recovery is to roll FORWARD with a fix, so the job just fails
+          loudly (no revert) and a human intervenes.
+        type: boolean
+        default: true
       post_deploy_checks:
         description: >-
           Optional bash commands run after the smoke test. Any non-zero exit
-          triggers rollback (same as the smoke test). Useful for service-specific
-          checks such as API endpoint assertions or DB migration verification.
+          fails the health gate (and triggers rollback only when auto_rollback is
+          true). Useful for service-specific checks such as API endpoint
+          assertions or DB migration verification.
           Only executed when health_gate is true.
           Example: |
             curl -fsS https://example.com/api/v1/chains/ | jq -e '.count > 0'
@@ -289,7 +300,7 @@ jobs:
           ${{ inputs.post_deploy_checks }}
 
       - name: Roll back on failed health gate
-        if: ${{ failure() && steps.commit.outputs.pushed == 'true' && inputs.health_gate }}
+        if: ${{ failure() && steps.commit.outputs.pushed == 'true' && inputs.health_gate && inputs.auto_rollback }}
         working-directory: infra
         env:
           DEPLOY_SHA: ${{ steps.commit.outputs.sha }}

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -9,8 +9,10 @@
 # tag onto the cluster automatically — CI never touches kubectl/helm.
 # Each deploy leaves a merged PR in infra-tf, enabling one-click GitHub reverts.
 #
-# Optional production gate: wait for ArgoCD health + smoke-test the service;
-# on failure, `git revert` the bump (ArgoCD rolls back to the previous tag).
+# Optional production gate: wait for ArgoCD health + smoke-test the service.
+# On failure the bump is reverted (ArgoCD rolls back to the previous tag) ONLY
+# when both health_gate and auto_rollback are true; otherwise the job fails
+# loudly and recovery is roll-forward (never revert across a DB migration).
 # -----------------------------------------------------------------------------
 name: _deploy
 
@@ -285,8 +287,9 @@ jobs:
           # Poll the service's version endpoint until it reports the tag we just
           # deployed — proof that ArgoCD reconciled the NEW image (not the old
           # pods). VPN-free readiness check for a GitOps rollout.
+          [ -n "$EXPECTED" ] || { echo "::error::empty image_tag — cannot verify rollout"; exit 1; }
           for i in $(seq 1 40); do
-            DEPLOYED=$(curl -fsS "$URL" | jq -r '.version' 2>/dev/null || echo "")
+            DEPLOYED=$(curl -fsS "$URL" 2>/dev/null | jq -r '.version // ""' 2>/dev/null || true)
             echo "attempt ${i}/40 — deployed=${DEPLOYED:-<none>} expected=${EXPECTED}"
             [ "$DEPLOYED" = "$EXPECTED" ] && { echo "Rollout confirmed: ${EXPECTED}"; exit 0; }
             sleep 15

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -45,6 +45,14 @@ on:
         description: URL to smoke-test after deploy (optional; production gate).
         type: string
         default: ""
+      version_check_url:
+        description: >-
+          Optional JSON endpoint exposing a `.version` field (e.g. /api/v1/about/).
+          After deploy, poll it until `.version` equals image_tag — confirms the
+          new image actually rolled out. VPN-free alternative to the ArgoCD wait
+          when the controller is unreachable (e.g. staging behind a separate VPN).
+        type: string
+        default: ""
       health_gate:
         description: >-
           Enable the full production gate: ArgoCD wait + smoke test + post-deploy
@@ -64,11 +72,10 @@ on:
         default: true
       post_deploy_checks:
         description: >-
-          Optional bash commands run after the smoke test. Any non-zero exit
-          fails the health gate (and triggers rollback only when auto_rollback is
-          true). Useful for service-specific checks such as API endpoint
-          assertions or DB migration verification.
-          Only executed when health_gate is true.
+          Optional bash commands run after the smoke test (whenever provided, for
+          staging and production). Any non-zero exit fails the job (and triggers
+          rollback only when health_gate and auto_rollback are both true). Useful
+          for service-specific checks such as API endpoint assertions.
           Example: |
             curl -fsS https://example.com/api/v1/chains/ | jq -e '.count > 0'
             curl -fsS https://example.com/api/v1/safe-apps/ | jq -e '.count > 0'
@@ -268,6 +275,25 @@ jobs:
           grep -q "Initialization Sequence Completed" /tmp/openvpn.log \
             || { cat /tmp/openvpn.log; echo "::error::VPN failed to initialize"; exit 1; }
 
+      - name: Wait for version rollout
+        if: ${{ inputs.version_check_url != '' }}
+        env:
+          EXPECTED: ${{ inputs.image_tag }}
+          URL: ${{ inputs.version_check_url }}
+        run: |
+          set -euo pipefail
+          # Poll the service's version endpoint until it reports the tag we just
+          # deployed — proof that ArgoCD reconciled the NEW image (not the old
+          # pods). VPN-free readiness check for a GitOps rollout.
+          for i in $(seq 1 40); do
+            DEPLOYED=$(curl -fsS "$URL" | jq -r '.version' 2>/dev/null || echo "")
+            echo "attempt ${i}/40 — deployed=${DEPLOYED:-<none>} expected=${EXPECTED}"
+            [ "$DEPLOYED" = "$EXPECTED" ] && { echo "Rollout confirmed: ${EXPECTED}"; exit 0; }
+            sleep 15
+          done
+          echo "::error::Timed out (10m) waiting for ${URL} to report version ${EXPECTED}"
+          exit 1
+
       - name: Wait for ArgoCD sync & health
         if: ${{ inputs.health_gate && inputs.argocd_app != '' }}
         env:
@@ -294,7 +320,7 @@ jobs:
           curl -fsS --retry 6 --retry-delay 10 --retry-all-errors "${{ inputs.health_url }}"
 
       - name: Custom post-deploy checks
-        if: ${{ inputs.health_gate && inputs.post_deploy_checks != '' }}
+        if: ${{ inputs.post_deploy_checks != '' }}
         run: |
           set -euo pipefail
           ${{ inputs.post_deploy_checks }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -43,11 +43,40 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
+      auto_rollback: ${{ steps.migrations.outputs.auto_rollback }}
     steps:
       - id: tag
         env:
           TAG: ${{ github.event.release.tag_name || inputs.tag }}
         run: echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      # Auto-rollback is only safe when the release carries NO DB migration:
+      # reverting the image across a migration mismatches code and schema and
+      # breaks the service. Detect migration files added/changed since the
+      # previous tag; if any, disable rollback so a failed gate is recovered
+      # forward by a human. Default to false (no rollback) when unsure — safe.
+      - id: migrations
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          PREV=$(git tag --sort=-v:refname | grep -vFx "$TAG" | head -1 || true)
+          if [ -z "$PREV" ]; then
+            echo "No previous tag found — defaulting auto_rollback=false (safe)."
+            echo "auto_rollback=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git diff --name-only "$PREV" "$TAG" | grep -qE '(^|/)migrations/.+\.py$'; then
+            echo "DB migrations changed between ${PREV} and ${TAG} → auto_rollback=false (recover forward)."
+            echo "auto_rollback=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "No migration changes between ${PREV} and ${TAG} → auto_rollback=true."
+            echo "auto_rollback=true" >> "$GITHUB_OUTPUT"
+          fi
 
   build:
     needs: [ci, prepare]
@@ -74,6 +103,10 @@ jobs:
       argocd_app: safe-config-service
       health_url: https://safe-config.safe.global/check/
       health_gate: true
+      # Migration-aware rollback: prepare sets this true only when the release
+      # carries no DB migration (safe to revert the image); a migration-bearing
+      # release keeps it false so a failed gate is recovered forward, not reverted.
+      auto_rollback: ${{ needs.prepare.outputs.auto_rollback == 'true' }}
       post_deploy_checks: |
         curl -fsS --retry 6 --retry-delay 10 --retry-all-errors https://safe-config.safe.global/api/v1/chains/ | jq -e '.count > 0'
         curl -fsS --retry 6 --retry-delay 10 --retry-all-errors https://safe-config.safe.global/api/v1/safe-apps/ | jq -e 'length > 0'

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -50,48 +50,30 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
-      auto_rollback: ${{ steps.migrations.outputs.auto_rollback }}
+      auto_rollback: ${{ steps.rollback.outputs.auto_rollback }}
     steps:
       - id: tag
         env:
           TAG: ${{ github.event.release.tag_name || inputs.tag }}
         run: echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0
-
-      # Auto-rollback safety:
-      #  - Manual dispatch: honour the `auto_rollback` input (operator decides).
-      #  - Release event: only safe when the release carries NO DB migration —
-      #    reverting the image across a migration mismatches code and schema and
-      #    breaks the service. Detect migration files added since the previous
-      #    tag; if any, disable rollback so a failed gate is recovered forward.
-      #    Default to false (no rollback) when unsure — safe.
-      - id: migrations
+      # Roll-forward by default. This service ships forward-only / destructive DB
+      # migrations, so reverting the image across a migration mismatches code and
+      # schema and breaks the service — a failed health gate fails loudly and is
+      # recovered FORWARD, never auto-reverted. Auto-rollback is opt-in and only
+      # via a manual dispatch, for a deploy the operator knows is migration-free.
+      - id: rollback
         env:
-          TAG: ${{ steps.tag.outputs.tag }}
           EVENT: ${{ github.event_name }}
           DISPATCH_ROLLBACK: ${{ inputs.auto_rollback }}
         run: |
           set -euo pipefail
           if [ "$EVENT" = "workflow_dispatch" ]; then
-            echo "Manual dispatch — auto_rollback=${DISPATCH_ROLLBACK} (from input)."
+            echo "Manual dispatch — auto_rollback=${DISPATCH_ROLLBACK} (operator opt-in)."
             echo "auto_rollback=${DISPATCH_ROLLBACK}" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          PREV=$(git tag --sort=-v:refname | grep -vFx "$TAG" | head -1 || true)
-          if [ -z "$PREV" ]; then
-            echo "No previous tag found — defaulting auto_rollback=false (safe)."
-            echo "auto_rollback=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if git diff --name-only "$PREV" "$TAG" | grep -qE '(^|/)migrations/.+\.py$'; then
-            echo "DB migrations changed between ${PREV} and ${TAG} → auto_rollback=false (recover forward)."
-            echo "auto_rollback=false" >> "$GITHUB_OUTPUT"
           else
-            echo "No migration changes between ${PREV} and ${TAG} → auto_rollback=true."
-            echo "auto_rollback=true" >> "$GITHUB_OUTPUT"
+            echo "Release event — auto_rollback=false (roll forward on failure)."
+            echo "auto_rollback=false" >> "$GITHUB_OUTPUT"
           fi
 
   build:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -23,6 +23,13 @@ on:
         description: Git tag / version to build and deploy (e.g. v2.97.0).
         type: string
         required: true
+      auto_rollback:
+        description: >-
+          Revert the image bump if the health gate fails (ArgoCD rolls back to
+          the previous tag). Leave OFF when the tag carries a DB migration —
+          reverting across a migration breaks the service (recover forward).
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -54,16 +61,25 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Auto-rollback is only safe when the release carries NO DB migration:
-      # reverting the image across a migration mismatches code and schema and
-      # breaks the service. Detect migration files added/changed since the
-      # previous tag; if any, disable rollback so a failed gate is recovered
-      # forward by a human. Default to false (no rollback) when unsure — safe.
+      # Auto-rollback safety:
+      #  - Manual dispatch: honour the `auto_rollback` input (operator decides).
+      #  - Release event: only safe when the release carries NO DB migration —
+      #    reverting the image across a migration mismatches code and schema and
+      #    breaks the service. Detect migration files added since the previous
+      #    tag; if any, disable rollback so a failed gate is recovered forward.
+      #    Default to false (no rollback) when unsure — safe.
       - id: migrations
         env:
           TAG: ${{ steps.tag.outputs.tag }}
+          EVENT: ${{ github.event_name }}
+          DISPATCH_ROLLBACK: ${{ inputs.auto_rollback }}
         run: |
           set -euo pipefail
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            echo "Manual dispatch — auto_rollback=${DISPATCH_ROLLBACK} (from input)."
+            echo "auto_rollback=${DISPATCH_ROLLBACK}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           PREV=$(git tag --sort=-v:refname | grep -vFx "$TAG" | head -1 || true)
           if [ -z "$PREV" ]; then
             echo "No previous tag found — defaulting auto_rollback=false (safe)."

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -4,8 +4,10 @@
 # =============================================================================
 # Triggered when release-please publishes a GitHub Release (tag vX.Y.Z).
 # Runs CI on the release commit, builds an immutable image tagged with the
-# release version, then GitOps-deploys it to production with a full health gate:
-# ArgoCD wait + smoke test + auto-rollback on failure.
+# release version, then GitOps-deploys it to production with a health gate:
+# ArgoCD wait + smoke test + API checks. The gate does NOT auto-rollback on a
+# release: it fails loudly and recovery is roll-forward (auto_rollback=false;
+# see the deploy-production job). Reverting across a DB migration is unsafe.
 #
 # workflow_dispatch is a manual recovery path: it runs THIS (fixed) workflow
 # from the default branch while building/deploying the tag you pass as `tag`.
@@ -101,9 +103,10 @@ jobs:
       argocd_app: safe-config-service
       health_url: https://safe-config.safe.global/check/
       health_gate: true
-      # Migration-aware rollback: prepare sets this true only when the release
-      # carries no DB migration (safe to revert the image); a migration-bearing
-      # release keeps it false so a failed gate is recovered forward, not reverted.
+      # Roll-forward for release: published (prepare hardcodes false); a manual
+      # workflow_dispatch may opt in via its auto_rollback input for a tag the
+      # operator knows is migration-free. Reverting across a DB migration is
+      # unsafe, so a failed release gate fails loudly and is recovered forward.
       auto_rollback: ${{ needs.prepare.outputs.auto_rollback == 'true' }}
       post_deploy_checks: |
         curl -fsS --retry 6 --retry-delay 10 --retry-all-errors https://safe-config.safe.global/api/v1/chains/ | jq -e '.count > 0'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,14 @@
 # exact source (deploy + /about/ version poll + smoke + API checks) BEFORE we
 # cut a release — so we never promote to production something staging rejected.
 #
+# Note: a workflow_run job checks out the default-branch HEAD at trigger time,
+# not the exact SHA staging validated. If main advances between staging turning
+# green and this firing, release-please runs against the newer commit. It is
+# mostly self-correcting — Staging uses cancel-in-progress, so a newer push
+# cancels the in-flight staging (conclusion != success) and must run its own
+# green staging to unlock a release — but the "only what staging validated"
+# guarantee is strict only while main doesn't advance in that narrow window.
+#
 # release-please keeps ONE rolling Release PR whose version and CHANGELOG are
 # derived from Conventional Commits. Merging that PR tags the commit, publishes
 # the GitHub Release (using the App token so the `release: published` event

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,16 +2,22 @@
 # =============================================================================
 # CALLER: release-please → automated release PR + GitHub Release
 # =============================================================================
-# Runs on every push to main. release-please keeps ONE rolling Release PR whose
-# version and CHANGELOG are derived from Conventional Commits. Merging that PR
-# tags the commit, publishes the GitHub Release (using the App token so the
-# `release: published` event fires), and triggers production.yml automatically.
+# Gated on a SUCCESSFUL staging deploy: runs only after the Staging workflow
+# (triggered by the same push to main) completes green. Staging validates the
+# exact source (deploy + /about/ version poll + smoke + API checks) BEFORE we
+# cut a release — so we never promote to production something staging rejected.
+#
+# release-please keeps ONE rolling Release PR whose version and CHANGELOG are
+# derived from Conventional Commits. Merging that PR tags the commit, publishes
+# the GitHub Release (using the App token so the `release: published` event
+# fires), and triggers production.yml automatically.
 # -----------------------------------------------------------------------------
 name: Release Please
 
 on:
-  push:
-    branches: [main]
+  workflow_run:
+    workflows: ["Staging"]
+    types: [completed]
 
 permissions:
   contents: write
@@ -19,6 +25,9 @@ permissions:
 
 jobs:
   release:
+    # Only when the push-triggered staging deploy passed. Manual staging
+    # dispatches don't cut releases.
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' }}
     uses: ./.github/workflows/_release.yml
     with:
       release_type: python

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -55,7 +55,15 @@ jobs:
       values_file: apps/safe-config-service/values-staging.yaml
       image_tag_path: .web.imageTag
       health_url: https://safe-config.staging.5afe.dev/check/
+      # Staging's ArgoCD is behind a separate, unconfigurable VPN — so instead of
+      # an ArgoCD wait, poll /about/ until it reports the tag we just deployed.
+      # This proves the new image rolled out (not the old pods) before the smoke
+      # test + API checks run, making "staging OK" a meaningful gate for prod.
+      version_check_url: https://safe-config.staging.5afe.dev/api/v1/about/
       health_gate: false
+      post_deploy_checks: |
+        curl -fsS --retry 6 --retry-delay 10 --retry-all-errors https://safe-config.staging.5afe.dev/api/v1/chains/ | jq -e '.count > 0'
+        curl -fsS --retry 6 --retry-delay 10 --retry-all-errors https://safe-config.staging.5afe.dev/api/v1/safe-apps/ | jq -e 'length > 0'
     secrets:
       app_id: ${{ secrets.CI_APP_ID }}
       app_private_key: ${{ secrets.CI_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Hardens the production deploy pipeline. No app code changes.

Roll-forward by default (no auto-rollback across migrations)
- Reverting the image across a forward-only / destructive DB migration
  mismatches code and schema and breaks the service — so the production
  release path never auto-reverts. On a failed health gate the job fails
  loudly and recovery is roll FORWARD (deploy a fix), not back.
- New `auto_rollback` input on _deploy.yml (default true — unchanged for
  other callers); the rollback step now also requires `inputs.auto_rollback`.
- production.yml: release path sets auto_rollback=false; a manual
  workflow_dispatch exposes an `auto_rollback` checkbox so an operator can
  opt in for a deploy they know is migration-free.

Gate production on a successful staging deploy
- release-please.yml now triggers via `workflow_run` on the Staging workflow
  completing successfully (event=push, conclusion=success), instead of a
  direct push to main — so prod only gets what staging validated.

VPN-free staging rollout verification
- New `version_check_url` input on _deploy.yml polls a JSON /about/ endpoint
  until `.version` equals image_tag (10-min timeout) — proof the new image
  rolled out (not the old pods) without ArgoCD access. Used for staging,
  whose ArgoCD is behind a separate, unconfigurable VPN.
- staging.yml adds the /about/ poll + API post-deploy checks.
- `post_deploy_checks` decoupled from `health_gate` (runs whenever provided).
