### PR TITLE
ci: Retry infra deploy merge with backoff (fix flaky branch-policy race)

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -208,18 +208,27 @@ jobs:
             --body "Automated deploy · [CI run #${GITHUB_RUN_ID}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})")
 
           # --squash produces a single commit on main signed by GitHub web-flow (Verified badge).
-          # Retry on conflict: rebase deploy branch on latest infra HEAD and re-attempt.
-          for attempt in 1 2 3; do
+          # Retry with backoff: right after the branch push GitHub is still recomputing
+          # the PR's branch-policy state (require_last_push_approval / dismiss_stale_reviews_
+          # on_push recompute per push), during which even a bypass-actor merge is transiently
+          # rejected with "base branch policy prohibits the merge". So wait and re-attempt the
+          # merge WITHOUT re-pushing (a force-push would reset that settle timer). Only rebase
+          # when infra main has actually advanced (real non-fast-forward / concurrent deploy).
+          for attempt in $(seq 1 8); do
             if gh pr merge "$PR_URL" --squash --delete-branch \
                  --subject "deploy(${ENVIRONMENT}): ${REPO} ${IMAGE_TAG}" \
                  --body ""; then
               break
             fi
-            [ "$attempt" -eq 3 ] && { echo "::error::PR merge failed after 3 attempts."; exit 1; }
-            echo "Merge attempt ${attempt} failed — rebasing deploy branch on infra HEAD"
+            [ "$attempt" -eq 8 ] && { echo "::error::PR merge failed after 8 attempts. Open PR: ${PR_URL}"; exit 1; }
+            echo "Merge attempt ${attempt} failed — waiting 20s for the branch policy to settle"
+            sleep 20
             git fetch origin
-            git rebase origin/main || { git rebase --abort; echo "::error::Rebase conflict — manual resolution required. Open PR: ${PR_URL}"; exit 1; }
-            git push --force-with-lease origin "$BRANCH"
+            if ! git merge-base --is-ancestor origin/main HEAD; then
+              echo "infra main advanced — rebasing deploy branch"
+              git rebase origin/main || { git rebase --abort; echo "::error::Rebase conflict — manual resolution required. Open PR: ${PR_URL}"; exit 1; }
+              git push --force-with-lease origin "$BRANCH"
+            fi
           done
 
           # mergeCommit.oid can lag a few seconds after gh pr merge returns.


### PR DESCRIPTION
The deploy PR was merged within ~6s of creation with 3 fast retries that force-pushed each time, resetting GitHub's branch-policy recompute window (require_last_push_approval / dismiss_stale_reviews_on_push) — so the bypass-actor merge was transiently rejected. Retry up to 8× with a 20s backoff and only rebase when infra main actually advanced (no needless force-push that would reset the settle timer).