### PR TITLE
ci: no-op trigger to validate end-to-end deploy pipeline

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,6 +9,9 @@
 # "Require branches up to date". Everything after merge is automated.
 #
 # (cla.yml and claude-code-review.yml stay as-is — they already run on PR events.)
+#
+# (no-op: merge triggers a full pipeline run to validate staging→release→prod
+#  end-to-end after the infra-tf bypass fix — 2026-07-22.)
 # -----------------------------------------------------------------------------
 name: Pull request
 


### PR DESCRIPTION
**Fake/no-op PR** — adds only a comment to `pull-request.yml`.

Purpose: merging this is a push to `main` that exercises the full pipeline end-to-end after re-saving the `safe-ci` bypass on the infra-tf enterprise ruleset:

1. `staging.yml` → build `main-<sha>` → deploy staging (infra-tf bump PR should now merge reliably) → `/api/v1/about/` version-poll + smoke + API checks.
2. On green staging → `release-please` publishes the pending **v2.98.0** (from #1623).
3. `release: published` → `production.yml` → build v2.98.0 → deploy prod → **VPN/OIDC health gate** (first real prod deploy via the new pipeline).

`ci:` type → does not cut a new release; the pending v2.98.0 is what ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)