### PR TITLE
ci: relabel released PRs to 'autorelease: tagged' (locked-PR workaround)

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -81,3 +81,33 @@ jobs:
           set -euo pipefail
           PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
           gh pr merge --auto --squash "$PR_NUMBER" --repo "$GITHUB_REPOSITORY"
+
+      # Safety-net for the recurring "stuck Release PR" problem.
+      # After publishing the Release, release-please tries to COMMENT on the
+      # merged Release PR — but this repo locks every PR on merge (org-wide
+      # policy), so the comment fails ("issue is locked") and the action aborts
+      # BEFORE swapping the PR label 'autorelease: pending' -> 'autorelease:
+      # tagged'. Left pending, the NEXT run retries creating the already-
+      # published release (422 already_exists) and no new release can be cut.
+      # We force the label swap here — editing labels is allowed on a locked
+      # PR (only commenting is blocked). Idempotent: a no-op when nothing is
+      # pending. (Relaxing the org lock policy would be the alternative, but it
+      # has org-wide blast radius; this fix is fully contained in our pipeline.)
+      - name: Mark released PRs as tagged (workaround for locked-PR comment failure)
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          pending=$(gh pr list --repo "$GITHUB_REPOSITORY" --state merged \
+            --label "autorelease: pending" --json number --jq '.[].number')
+          if [ -z "$pending" ]; then
+            echo "No merged PR left on 'autorelease: pending' — nothing to do."
+            exit 0
+          fi
+          for n in $pending; do
+            echo "Relabeling merged Release PR #${n}: 'autorelease: pending' -> 'autorelease: tagged'"
+            gh pr edit "$n" --repo "$GITHUB_REPOSITORY" \
+              --remove-label "autorelease: pending" \
+              --add-label "autorelease: tagged"
+          done

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -84,30 +84,32 @@ jobs:
 
       # Safety-net for the recurring "stuck Release PR" problem.
       # After publishing the Release, release-please tries to COMMENT on the
-      # merged Release PR — but this repo locks every PR on merge (org-wide
+      # just-merged Release PR — but this repo locks PRs on merge (org-wide
       # policy), so the comment fails ("issue is locked") and the action aborts
-      # BEFORE swapping the PR label 'autorelease: pending' -> 'autorelease:
+      # BEFORE swapping that PR's label 'autorelease: pending' -> 'autorelease:
       # tagged'. Left pending, the NEXT run retries creating the already-
       # published release (422 already_exists) and no new release can be cut.
-      # We force the label swap here — editing labels is allowed on a locked
-      # PR (only commenting is blocked). Idempotent: a no-op when nothing is
-      # pending. (Relaxing the org lock policy would be the alternative, but it
-      # has org-wide blast radius; this fix is fully contained in our pipeline.)
-      - name: Mark released PRs as tagged (workaround for locked-PR comment failure)
+      # We swap the label ourselves — editing labels is allowed on a locked PR
+      # (only commenting is blocked). Scoped to the single PR that was just
+      # released (the one whose squash-merge commit is this run's release SHA),
+      # not every pending PR. Idempotent: a no-op if that PR is already tagged.
+      - name: Mark the released PR as tagged (workaround for locked-PR comment failure)
         if: ${{ steps.release.outputs.release_created == 'true' }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          RELEASED_SHA: ${{ steps.release.outputs.sha }}
         run: |
           set -euo pipefail
-          pending=$(gh pr list --repo "$GITHUB_REPOSITORY" --state merged \
-            --label "autorelease: pending" --json number --jq '.[].number')
-          if [ -z "$pending" ]; then
-            echo "No merged PR left on 'autorelease: pending' — nothing to do."
+          # The Release PR just merged is the one whose merge commit is the
+          # released SHA and still carries the pending label — only touch that one.
+          pr=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${RELEASED_SHA}/pulls" \
+            --jq '.[] | select([.labels[].name] | index("autorelease: pending")) | .number' \
+            | head -n1)
+          if [ -z "$pr" ]; then
+            echo "No merged Release PR on 'autorelease: pending' for ${RELEASED_SHA} — nothing to do."
             exit 0
           fi
-          for n in $pending; do
-            echo "Relabeling merged Release PR #${n}: 'autorelease: pending' -> 'autorelease: tagged'"
-            gh pr edit "$n" --repo "$GITHUB_REPOSITORY" \
-              --remove-label "autorelease: pending" \
-              --add-label "autorelease: tagged"
-          done
+          echo "Relabeling Release PR #${pr}: 'autorelease: pending' -> 'autorelease: tagged'"
+          gh pr edit "$pr" --repo "${GITHUB_REPOSITORY}" \
+            --remove-label "autorelease: pending" \
+            --add-label "autorelease: tagged"


### PR DESCRIPTION
release-please publishes the Release but then fails to comment on the merged Release PR because the repo locks PRs on merge; it aborts before swapping the 'autorelease: pending' label to 'tagged', which blocks the next release (422 already_exists). Force the swap in a contained step (label edits are allowed on locked PRs). Idempotent; no org lock-policy change needed.