### PR TITLE
ci: bind workflow_call inputs to env before shell

### DIFF
--- a/.github/workflows/_build-image.yml
+++ b/.github/workflows/_build-image.yml
@@ -74,10 +74,14 @@ jobs:
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Compute image tags
         id: tags
+        env:
+          IMAGE_NAME: ${{ inputs.image_name }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
+          ALSO_TAG_LATEST: ${{ inputs.also_tag_latest }}
         run: |
-          TAGS="${{ inputs.image_name }}:${{ inputs.image_tag }}"
-          if [ "${{ inputs.also_tag_latest }}" = "true" ]; then
-            TAGS="${TAGS}"$'\n'"${{ inputs.image_name }}:latest"
+          TAGS="${IMAGE_NAME}:${IMAGE_TAG}"
+          if [ "${ALSO_TAG_LATEST}" = "true" ]; then
+            TAGS="${TAGS}"$'\n'"${IMAGE_NAME}:latest"
           fi
           {
             echo "tags<<EOF"

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -329,6 +329,7 @@ jobs:
         env:
           ARGOCD_SERVER: ${{ secrets.argocd_server }}
           ARGOCD_AUTH_TOKEN: ${{ steps.argocd-secrets.outputs.token || secrets.argocd_token }}
+          ARGOCD_APP: ${{ inputs.argocd_app }}
         run: |
           set -euo pipefail
           if [ -z "${ARGOCD_SERVER:-}" ] || [ -z "${ARGOCD_AUTH_TOKEN:-}" ]; then
@@ -340,20 +341,24 @@ jobs:
           curl -sSL -o /tmp/argocd \
             "https://github.com/argoproj/argo-cd/releases/download/${ARGOCD_VERSION}/argocd-linux-amd64"
           chmod +x /tmp/argocd
-          /tmp/argocd app wait "${{ inputs.argocd_app }}" \
+          /tmp/argocd app wait "${ARGOCD_APP}" \
             --health --sync --timeout 300 --grpc-web
 
       - name: Smoke test
         if: ${{ inputs.health_url != '' }}
+        env:
+          HEALTH_URL: ${{ inputs.health_url }}
         run: |
           set -euo pipefail
-          curl -fsS --retry 6 --retry-delay 10 --retry-all-errors "${{ inputs.health_url }}"
+          curl -fsS --retry 6 --retry-delay 10 --retry-all-errors "${HEALTH_URL}"
 
       - name: Custom post-deploy checks
         if: ${{ inputs.post_deploy_checks != '' }}
+        env:
+          POST_DEPLOY_CHECKS: ${{ inputs.post_deploy_checks }}
         run: |
           set -euo pipefail
-          ${{ inputs.post_deploy_checks }}
+          bash -lc "$POST_DEPLOY_CHECKS"
 
       - name: Roll back on failed health gate
         if: ${{ failure() && steps.commit.outputs.pushed == 'true' && inputs.health_gate && inputs.auto_rollback }}


### PR DESCRIPTION
## Summary
Reusable deploy/build workflows interpolated several `workflow_call` inputs directly into `run:` scripts (`argocd_app`, `health_url`, `post_deploy_checks`, image name/tag). Move those values into `env:` and expand shell variables instead.

## Test plan
- [ ] `_build-image` still emits expected tag list (incl. optional `:latest`)
- [ ] Deploy health/smoke / post-deploy check steps still run when inputs are set
- [ ] ArgoCD wait still targets the configured app name


Made with [Cursor](https://cursor.com)